### PR TITLE
Added IPv6 address support in IPUtils methods that check IP address validity

### DIFF
--- a/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/util/IPUtils.java
+++ b/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/util/IPUtils.java
@@ -12,26 +12,43 @@ import java.util.regex.Pattern;
  * @author ETj (etj at geo-solutions.it)
  */
 public class IPUtils {
-
     private static final String IPV4_ADDRESS = "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})";
-    private static final String SLASH_FORMAT = IPV4_ADDRESS + "/(\\d{1,3})";
-    private static final Pattern cidrPattern = Pattern.compile(SLASH_FORMAT);
-    private static final Pattern ipv4Pattern = Pattern.compile(IPV4_ADDRESS);
+    private static final String IPV6_STANDARD_ADDRESS = "(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}";
+    private static final String IPV6_COMPRESSED_ADDRESS = "((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)";
+    
+    private static final String SLASH_FORMAT = "/(\\d{1,3})";
+    
+    private static final Pattern[] ipAddressPatterns = new Pattern[] {
+        Pattern.compile(IPV4_ADDRESS),
+        Pattern.compile(IPV6_STANDARD_ADDRESS),
+        Pattern.compile(IPV6_COMPRESSED_ADDRESS)
+    };
+    
+    private static final Pattern[] cidrPatterns = new Pattern[] {
+        Pattern.compile(IPV4_ADDRESS + SLASH_FORMAT),
+        Pattern.compile(IPV6_STANDARD_ADDRESS + SLASH_FORMAT),
+        Pattern.compile(IPV6_COMPRESSED_ADDRESS + SLASH_FORMAT)
+    };
+    
 
     public static boolean isAddressValid(String ipAddress) {
+        return checkAllPatterns(ipAddress, ipAddressPatterns);
+    }
+
+    private static boolean checkAllPatterns(String ipAddress, Pattern[] patterns) {
         if(ipAddress == null) {
             return false;
         }
-
-        return ipv4Pattern.matcher(ipAddress).matches();
+        for(Pattern pattern : patterns) {
+            if(pattern.matcher(ipAddress).matches()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean isRangeValid(String ipAddressRange) {
-        if(ipAddressRange == null) {
-            return false;
-        }
-
-        return cidrPattern.matcher(ipAddressRange).matches();
+        return checkAllPatterns(ipAddressRange, cidrPatterns);
     }
 
 

--- a/src/services/core/services-api/src/test/java/org/geoserver/geofence/services/util/IPUtilsTest.java
+++ b/src/services/core/services-api/src/test/java/org/geoserver/geofence/services/util/IPUtilsTest.java
@@ -1,0 +1,37 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.services.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class IPUtilsTest {
+    @Test
+    public void testIPv4() {
+        assertTrue(IPUtils.isAddressValid("192.168.1.1"));
+        assertTrue(IPUtils.isAddressValid("127.0.0.1"));
+        assertFalse(IPUtils.isAddressValid("192.168.1.1.2"));
+        
+        assertTrue(IPUtils.isRangeValid("192.168.1.0/32"));
+        assertTrue(IPUtils.isRangeValid("127.0.0.1/8"));
+        assertFalse(IPUtils.isRangeValid("127.0.0.1/1111"));
+        assertFalse(IPUtils.isRangeValid("127.0.0.1/32/2"));
+    }
+    
+    @Test
+    public void testIPv6() {
+        assertTrue(IPUtils.isAddressValid("0:0:0:0:0:0:0:1"));
+        assertTrue(IPUtils.isAddressValid("B012:a000:361:44:f87:11:0:0"));
+        assertTrue(IPUtils.isAddressValid("::1"));
+        
+        assertFalse(IPUtils.isAddressValid("B012:a000:361:44:f87:11:0:g0"));
+        assertFalse(IPUtils.isAddressValid("B012:a000:361:44:f87:11:0"));
+        
+        assertTrue(IPUtils.isRangeValid("0:0:0:0:0:0:0:1/32"));
+        assertFalse(IPUtils.isRangeValid("0:0:0:0:0:0:0:1/32/1"));
+    }
+}


### PR DESCRIPTION
Avoids exceptions if the client sends an IPv6 address.
Still to address full IPv6 compatibility with IP based rules.