### PR TITLE
Update ibiblio repsoitory URL

### DIFF
--- a/src/gui/pom.xml
+++ b/src/gui/pom.xml
@@ -78,7 +78,7 @@
         </repository>
         <repository>
             <id>ibiblio</id>
-            <url>http://mirrors.ibiblio.org/pub/mirrors/maven2/</url>
+            <url>http://maven.ibiblio.org/maven2/</url>
         </repository>
         <repository>
             <id>osgeo-geotools</id>

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -925,7 +925,7 @@
         <repository>
             <id>ibiblio-maven2-repository</id>
             <name>ibiblio Repository for Maven</name>
-            <url>http://mirrors.ibiblio.org/maven2</url>
+            <url>http://maven.ibiblio.org/maven2/</url>
             <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>


### PR DESCRIPTION
The old URL have been permanently moved and Maven3 cannot handle it.