### PR TITLE
Possibility to specify a custom key for password encryption

### DIFF
--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/util/PwEncoder.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/util/PwEncoder.java
@@ -21,9 +21,14 @@ import javax.xml.bind.DatatypeConverter;
  */
 public class PwEncoder {
 
-    // 123456789 123456789 123456789 12
-    private static final byte[] KEY = "installation dependant key needed".substring(0, 16)
-            .getBytes();
+    private static final byte[] KEY;
+    static {
+      String strKey = System.getProperty("GEOFENCE_PWENCODER_KEY");
+      if (strKey == null) {
+        strKey = "installation dependant key needed";
+      }
+      KEY = strKey.substring(0, 16).getBytes();
+    }
 
     public static String encode(String msg) {
         try {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/util/PwEncoder.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/util/PwEncoder.java
@@ -21,18 +21,17 @@ import javax.xml.bind.DatatypeConverter;
  */
 public class PwEncoder {
 
-    private static final byte[] KEY;
-    static {
-      String strKey = System.getProperty("GEOFENCE_PWENCODER_KEY");
-      if (strKey == null) {
-        strKey = "installation dependant key needed";
-      }
-      KEY = strKey.substring(0, 16).getBytes();
+    private static byte[] getKey() {
+        String strKey = System.getProperty("GEOFENCE_PWENCODER_KEY");
+        if (strKey == null || strKey.length() < 16) {
+          strKey = "installation dependant key needed";
+        }
+        return strKey.substring(0, 16).getBytes();
     }
 
     public static String encode(String msg) {
         try {
-            SecretKeySpec keySpec = new SecretKeySpec(KEY, "AES");
+            SecretKeySpec keySpec = new SecretKeySpec(getKey(), "AES");
             Cipher cipher = Cipher.getInstance("AES");
             cipher.init(Cipher.ENCRYPT_MODE, keySpec);
 
@@ -55,7 +54,7 @@ public class PwEncoder {
 
     public static String decode(String msg) {
         try {
-            SecretKeySpec keySpec = new SecretKeySpec(KEY, "AES");
+            SecretKeySpec keySpec = new SecretKeySpec(getKey(), "AES");
             Cipher cipher = Cipher.getInstance("AES");
             cipher.init(Cipher.DECRYPT_MODE, keySpec);
 

--- a/src/services/core/model/src/test/java/org/geoserver/geofence/core/model/util/PwEncoderTest.java
+++ b/src/services/core/model/src/test/java/org/geoserver/geofence/core/model/util/PwEncoderTest.java
@@ -3,7 +3,7 @@
  * application directory.
  */
 
-package org.geoserver.geofence.core.dao.util;
+package org.geoserver.geofence.core.model.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/util/PwEncoder.java
+++ b/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/util/PwEncoder.java
@@ -22,18 +22,17 @@ import org.apache.commons.codec.binary.Base64;
  */
 public class PwEncoder {
 
-    private static final byte[] KEY;
-    static {
+    private static byte[] getKey() {
       String strKey = System.getProperty("GEOFENCE_PWENCODER_KEY");
-      if (strKey == null) {
+      if (strKey == null || strKey.length() < 16) {
         strKey = "installation dependant key needed";
       }
-      KEY = strKey.substring(0, 16).getBytes();
+      return strKey.substring(0, 16).getBytes();
     }
 
     public static String encode(String msg) {
         try {
-            SecretKeySpec keySpec = new SecretKeySpec(KEY, "AES");
+            SecretKeySpec keySpec = new SecretKeySpec(getKey(), "AES");
             Cipher cipher = Cipher.getInstance("AES");
             cipher.init(Cipher.ENCRYPT_MODE, keySpec);
 
@@ -56,7 +55,7 @@ public class PwEncoder {
 
     public static String decode(String msg) {
         try {
-            SecretKeySpec keySpec = new SecretKeySpec(KEY, "AES");
+            SecretKeySpec keySpec = new SecretKeySpec(getKey(), "AES");
             Cipher cipher = Cipher.getInstance("AES");
             cipher.init(Cipher.DECRYPT_MODE, keySpec);
 

--- a/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/util/PwEncoder.java
+++ b/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/util/PwEncoder.java
@@ -22,9 +22,14 @@ import org.apache.commons.codec.binary.Base64;
  */
 public class PwEncoder {
 
-    // 123456789 123456789 123456789 12
-    private static final byte[] KEY = "installation dependant key needed".substring(0, 16)
-            .getBytes();
+    private static final byte[] KEY;
+    static {
+      String strKey = System.getProperty("GEOFENCE_PWENCODER_KEY");
+      if (strKey == null) {
+        strKey = "installation dependant key needed";
+      }
+      KEY = strKey.substring(0, 16).getBytes();
+    }
 
     public static String encode(String msg) {
         try {


### PR DESCRIPTION
Passwords are compromised by using a known key. It is possible to specify the custom key via the system property `GEOFENCE_PWENCODER_KEY`.  If the property is not set, it falls back to the original known key.