### PR TITLE
Fixes #119: nested groups support in LDAP DAO

### DIFF
--- a/src/services/modules/ldap/src/main/java/org/geoserver/geofence/ldap/dao/impl/GSUserDAOLdapImpl.java
+++ b/src/services/modules/ldap/src/main/java/org/geoserver/geofence/ldap/dao/impl/GSUserDAOLdapImpl.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.geofence.ldap.dao.impl;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -21,16 +23,22 @@ import com.googlecode.genericdao.search.Search;
  * @author "Mauro Bartolomeoli - mauro.bartolomeoli@geo-solutions.it"
  * @author Emanuele Tajariol (etj at geo-solutions.it)
  */
-public class GSUserDAOLdapImpl extends LDAPBaseDAO<GSUserDAO, GSUser> implements GSUserDAO
-{
+public class GSUserDAOLdapImpl extends LDAPBaseDAO<GSUserDAO, GSUser> implements GSUserDAO {
 
     private UserGroupDAOLdapImpl userGroupDAOLdapImpl;
+
+    private String memberFilter = null;
+
+    private String nestedMemberFilter = null;
+
+    private boolean enableHierarchicalGroups = false;
+
+    private int maxLevelGroupsSearch = Integer.MAX_VALUE;
 
     /**
      *
      */
-    public GSUserDAOLdapImpl()
-    {
+    public GSUserDAOLdapImpl() {
         super();
         // set default search base and filter for users
         setSearchBase("ou=People");
@@ -43,49 +51,70 @@ public class GSUserDAOLdapImpl extends LDAPBaseDAO<GSUserDAO, GSUser> implements
      * @param user
      * @return
      */
-    private List<UserGroup> getGroups(GSUser user)
-    {
+    private List<UserGroup> getGroups(GSUser user) {
         Filter filter = new Filter();
         String member;
         List<UserGroup> groups;
         String filterStr = null;
 
         String dn = user.getExtId();
-        if(StringUtils.isNotBlank(dn)) {
+        String userName = user.getName();
+        if (memberFilter != null) {
+            filterStr = MessageFormat.format(memberFilter, new String[] { dn, userName });
+        } else if (StringUtils.isNotBlank(dn)) {
             filter = new Filter("member", dn);
         } else {
-            String userName = user.getName();
-            LOGGER.info("User id is null, using username '"+userName+"'");
+            LOGGER.info("User id is null, using username '" + userName + "'");
             String nameAttr = getLDAPAttribute("username");
             String memberSearchFilterAttr = getLDAPAttribute("memberSearchFilter");
-            //e.g  memberSearchFilter = uniqueMember=uid={0},ou=users,ou=project,dc=edata,dc=comp,dc=be
-            if(memberSearchFilterAttr != null) {
-                //e.g String member = nameAttr + "=" + userName;
-                String val = memberSearchFilterAttr.split("=")[0];  //e.g  get uniqueMember part
-                member = memberSearchFilterAttr.split("=",2)[1];    //e.g  remove uniqueMember part
+            // e.g memberSearchFilter = uniqueMember=uid={0},ou=users,ou=project,dc=edata,dc=comp,dc=be
+            if (memberSearchFilterAttr != null) {
+                // e.g String member = nameAttr + "=" + userName;
+                String val = memberSearchFilterAttr.split("=")[0]; // e.g get uniqueMember part
+                member = memberSearchFilterAttr.split("=", 2)[1]; // e.g remove uniqueMember part
                 member = member.replace("{0}", userName);
                 filterStr = val + '=' + member;
             } else {
                 String exp = nameAttr + "=" + userName;
                 filter = new Filter("member", exp);
             }
-         }
+        }
         if (filterStr == null) {
             groups = userGroupDAOLdapImpl.search(filter);
         } else {
             groups = userGroupDAOLdapImpl.search(filterStr);
         }
+        if (enableHierarchicalGroups && nestedMemberFilter != null) {
+            for (UserGroup group : groups) {
+                groups = addParentGroups(groups, group, 0);
+            }
+        }
+        return groups;
+    }
 
+    private List<UserGroup> addParentGroups(List<UserGroup> groups, UserGroup group, int level) {
+        if (level < maxLevelGroupsSearch) {
+            List<UserGroup> newGroups = new ArrayList<UserGroup>();
+            newGroups.addAll(groups);
+            String filter = MessageFormat.format(nestedMemberFilter,
+                    new String[] { group.getExtId(), group.getName() });
+            for(UserGroup parentGroup : (List<UserGroup>)userGroupDAOLdapImpl.search(filter)) {
+                if (!newGroups.contains(parentGroup)) {
+                    newGroups.add(parentGroup);
+                    newGroups = addParentGroups(newGroups, parentGroup, level + 1);
+                }
+            }
+            return newGroups;
+        }
         return groups;
     }
 
     @Override
-    public GSUser getFull(String name)
-    {
+    public GSUser getFull(String name) {
         GSUser user = searchByName(name);
-        if(user == null)
+        if (user == null)
             return null;
-        
+
         return fillWithGroups(user);
     }
 
@@ -95,8 +124,7 @@ public class GSUserDAOLdapImpl extends LDAPBaseDAO<GSUserDAO, GSUser> implements
      * @param gsUser
      * @return
      */
-    private GSUser fillWithGroups(GSUser user)
-    {
+    private GSUser fillWithGroups(GSUser user) {
         user.setGroups(new HashSet(getGroups(user)));
         return user;
     }
@@ -107,17 +135,31 @@ public class GSUserDAOLdapImpl extends LDAPBaseDAO<GSUserDAO, GSUser> implements
         search.addFilter(new Filter("username", name));
         List<GSUser> users = search(search);
 
-        if(users.isEmpty())
+        if (users.isEmpty())
             return null;
-        else if(users.size() > 1)
-            throw new IllegalArgumentException("Given filter ("+name+") returns too many users ("+users.size()+")");
+        else if (users.size() > 1)
+            throw new IllegalArgumentException(
+                    "Given filter (" + name + ") returns too many users (" + users.size() + ")");
         GSUser user = users.get(0);
         return user;
     }
 
-    public void setUserGroupDAOLdapImpl(UserGroupDAOLdapImpl userGroupDAOLdapImpl)
-    {
+    public void setUserGroupDAOLdapImpl(UserGroupDAOLdapImpl userGroupDAOLdapImpl) {
         this.userGroupDAOLdapImpl = userGroupDAOLdapImpl;
     }
 
+    public void setMemberFilter(String memberFilter) {
+        this.memberFilter = memberFilter;
+        if (this.nestedMemberFilter == null) {
+            this.nestedMemberFilter = memberFilter;
+        }
+    }
+
+    public void setNestedMemberFilter(String nestedMemberFilter) {
+        this.nestedMemberFilter = nestedMemberFilter;
+    }
+
+    public void setEnableHierarchicalGroups(boolean enableHierarchicalGroups) {
+        this.enableHierarchicalGroups = enableHierarchicalGroups;
+    }
 }

--- a/src/services/modules/ldap/src/test/java/org/geoserver/geofence/ldap/dao/impl/GSUserDAOLdapImplTest.java
+++ b/src/services/modules/ldap/src/test/java/org/geoserver/geofence/ldap/dao/impl/GSUserDAOLdapImplTest.java
@@ -95,5 +95,34 @@ public class GSUserDAOLdapImplTest extends BaseDAOTest
         assertTrue(gnames.contains("destination"));
         assertTrue(gnames.contains("otherGroup"));
     }
+    
+    @Test
+    public void test_getFullByName_hierarchicalGroups()
+    {
+        ((GSUserDAOLdapImpl)userDAO).setEnableHierarchicalGroups(true);
+        ((GSUserDAOLdapImpl)userDAO).setMemberFilter("member={0}");
+        ((GSUserDAOLdapImpl)userDAO).setNestedMemberFilter("member={0}");
+        try {
+            GSUser user = userDAO.getFull("destination2");
+            
+            assertNotNull(user);
+            assertEquals("destination2", user.getName());
+            assertEquals(3, user.getGroups().size());
+            
+            Set<String> gnames = new HashSet<>();
+            for (UserGroup g : user.getGroups()) {
+                LOGGER.debug("group : " + g.getName());
+                gnames.add(g.getName());
+            }
+    
+            assertTrue(gnames.contains("destination"));
+            assertTrue(gnames.contains("otherGroup"));
+            assertTrue(gnames.contains("parent"));
+        } finally {
+            ((GSUserDAOLdapImpl)userDAO).setEnableHierarchicalGroups(false);
+            ((GSUserDAOLdapImpl)userDAO).setMemberFilter(null);
+            ((GSUserDAOLdapImpl)userDAO).setNestedMemberFilter(null);
+        }
+    }
 
 }

--- a/src/services/modules/ldap/src/test/java/org/geoserver/geofence/ldap/dao/impl/UserGroupDAOLdapImplTest.java
+++ b/src/services/modules/ldap/src/test/java/org/geoserver/geofence/ldap/dao/impl/UserGroupDAOLdapImplTest.java
@@ -34,7 +34,7 @@ public class UserGroupDAOLdapImplTest extends BaseDAOTest
         assertTrue("Empty group name", group.getName().length() > 0);
 
 
-        Set<String> expected = new HashSet<>(Arrays.asList(new String[]{"adminGroup", "other", "otherGroup", "destination"}));
+        Set<String> expected = new HashSet<>(Arrays.asList(new String[]{"adminGroup", "parent", "other", "otherGroup", "destination"}));
         Set<String> found = new HashSet<>();
         for (UserGroup g : groups) {
             LOGGER.debug("Found group " + g);
@@ -65,6 +65,6 @@ public class UserGroupDAOLdapImplTest extends BaseDAOTest
     @Test
     public void testCount()
     {
-        assertEquals(4, userGroupDAO.count(new Search()));
+        assertEquals(5, userGroupDAO.count(new Search()));
     }
 }

--- a/src/services/modules/ldap/src/test/resources/data.ldif
+++ b/src/services/modules/ldap/src/test/resources/data.ldif
@@ -54,6 +54,16 @@ cn: otherGroup
 member: cn=destination2,ou=People,dc=example,dc=com
 member: cn=destination2
 
+dn: cn=parent,ou=Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: parent
+member: cn=destination,ou=Groups,dc=example,dc=com
+member: cn=otherGroup,ou=Groups,dc=example,dc=com
+# test ldap server won't return the dn
+member: cn=destination
+member: cn=otherGroup
+
 
 dn: cn=destination1,ou=People,dc=example,dc=com
 objectClass: top


### PR DESCRIPTION
I introduced new parameters for gsUserDAO_LDAP:

 * memberFilter (e.g. memberFilter=member={0}): generic filter for membership
 * nestedMemberFilter: generic filter for membership of groups inside other groups (defaults to memberFilter value)
 * enableHierarchicalGroups (true / false): fetches groups in a hierarchical way
 * maxLevelGroupsSearch: (defaults to inifinite): how deep to navigate groups hierarchically