### PR TITLE
Change to repo.osgeo.org

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -74,39 +74,38 @@
    
    <repositories>
 
-      <repository>
-         <id>boundless</id>
-         <name>Boundless Maven Repository</name>
-         <url>https://repo.boundlessgeo.com/main</url>
-         <snapshots>
-            <enabled>true</enabled>
-         </snapshots>
-      </repository>
+     <repository>
+      <id>osgeo-releases</id>
+      <name>OSGeo Nexus Release Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+      <snapshots><enabled>false</enabled></snapshots>
+      <releases><enabled>true</enabled></releases>
+     </repository>
 
-      <repository>
-         <id>osgeo</id>
-         <name>Open Source Geospatial Foundation Repository</name>
-         <url>http://download.osgeo.org/webdav/geotools/</url>
-         <snapshots>
-            <enabled>true</enabled>
-         </snapshots>
-      </repository>
+     <repository>
+      <id>osgeo-snapshots</id>
+      <name>OSGeo Nexus Snapshot Repository</name>
+      <url>https://repo.osgeo.org/repository/snapshot/</url>
+      <snapshots><enabled>true</enabled></snapshots>
+      <releases><enabled>false</enabled></releases>
+     </repository>
    </repositories>
 
    <distributionManagement>
-      <repository>
-        <id>boundless</id>
-        <name>Boundless Release Repository</name>
-        <url>https://repo.boundlessgeo.com/release/</url>
-        <uniqueVersion>false</uniqueVersion>
-      </repository>
-      <snapshotRepository>
-        <id>boundless</id>
-        <uniqueVersion>false</uniqueVersion>
-        <name>Boundless Snapshot Repository</name>
-        <url>https://repo.boundlessgeo.com/snapshot/</url>
-      </snapshotRepository>
+     <repository>
+       <id>nexus</id>
+       <name>OSGeo Release Repository</name>
+       <url>https://repo.osgeo.org/repository/Geoserver-releases/</url>
+       <uniqueVersion>false</uniqueVersion>
+     </repository>
+     <snapshotRepository>
+       <id>nexus</id>
+       <uniqueVersion>false</uniqueVersion>
+       <name>OSGeo Snapshot Repository</name>
+       <url>https://repo.osgeo.org/repository/geoserver-snapshots/</url>
+     </snapshotRepository>
    </distributionManagement>
+   
    <!-- distributionManagement>
         <downloadUrl>http://maven.geo-solutions.it</downloadUrl>
         <repository>


### PR DESCRIPTION
The build.geoserver.org jobs for geofence are failing due to missing dependencies, switching over to repo.osgeo.org repositories.