### PR TITLE
Bump commons-beanutils version and centralize version management

### DIFF
--- a/src/gui/pom.xml
+++ b/src/gui/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <module.name>geofence-gui</module.name>
         <geofence-version>3.5-SNAPSHOT</geofence-version>
-        <gt-version>20-SNAPSHOT</gt-version>
+        <gt-version>25-SNAPSHOT</gt-version>
         <geogwt-version>0.4-SNAPSHOT</geogwt-version>
 
         <spring.version>4.2.5.RELEASE</spring.version>
@@ -58,49 +58,12 @@
     <inceptionYear>2011</inceptionYear>
 
     <repositories>
-        <repository>
-            <id>geosolutions</id>
-            <name>GeoSolutions Repository</name>
-            <url>http://maven.geo-solutions.it</url>
-        </repository>
-        <repository>
-            <id>gwt-maven</id>
-            <url>http://gwt-maven.googlecode.com/svn/trunk/mavenrepo</url>
-        </repository>
-        <repository>
-            <id>osgeo-geotools</id>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-        <repository>
-            <id>boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>http://repo.boundlessgeo.com/main/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
+         <repository>
             <id>maven-restlet</id>
             <name>Restlet Maven Repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.talend.com/</url>
             <snapshots>
                 <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>ucdavis</id>
-            <name>Univ of California Maven Repository</name>
-            <url>http://maven.ucdavis.edu/maven2</url>
-            <snapshots>
-                <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>
@@ -476,7 +439,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.7.0</version>
+                <version>${commons-beanutils.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -20,6 +20,7 @@
      <hibernate-spatial-h2-version>1.1.3.1</hibernate-spatial-h2-version>
      <postgresql.jdbc.version>42.1.1</postgresql.jdbc.version>
      <postgis.jdbc.version>1.3.3</postgis.jdbc.version>
+     <commons-beanutils.version>1.9.4</commons-beanutils.version>
    </properties>
    
    <name>Master GeoFence POM</name>

--- a/src/services/modules/rest/impl/pom.xml
+++ b/src/services/modules/rest/impl/pom.xml
@@ -90,11 +90,13 @@
             <artifactId>spring-tx</artifactId>
         </dependency>
 
+<!--
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-api</artifactId>
             <type>jar</type>
         </dependency>
+        -->
 
         <dependency>
             <groupId>net.sf.json-lib</groupId>
@@ -209,12 +211,4 @@
         </plugins>
     </reporting>
 
-    <repositories>
-        <repository>
-            <url>http://repo1.maven.org/maven2/</url>
-            <id>junit_4</id>
-            <layout>default</layout>
-            <name>Repository for library Library[junit_4]</name>
-        </repository>
-    </repositories>
 </project>

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -30,7 +30,7 @@
         <geofence-version>3.5-SNAPSHOT</geofence-version>
         <main-prefix>geofence</main-prefix>
 
-        <gt-version>21-SNAPSHOT</gt-version>
+        <gt-version>25-SNAPSHOT</gt-version>
 
         <cxf-version>3.1.5</cxf-version>
         <activemq-version>5.3.0.4-fuse</activemq-version>
@@ -57,7 +57,6 @@
         <commons-logging-version>1.1.2</commons-logging-version>
         <commons-lang-version>2.3</commons-lang-version>
         <commons-collections-version>3.2</commons-collections-version>
-        <commons-beanutils-version>1.7.0</commons-beanutils-version>
         <commons-dbcp-version>1.2.2</commons-dbcp-version>
         <commons-codec-version>1.4</commons-codec-version>
 
@@ -306,7 +305,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils-version}</version>
+                <version>${commons-beanutils.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>
@@ -870,12 +869,13 @@
     </build>
 
     <repositories>
-    		<!-- GeoSolutions -->
+    		<!-- GeoSolutions 
         <repository>
             <id>geosolutions</id>
             <name>GeoSolutions Repository</name>
-            <url>http://maven.geo-solutions.it</url>
+            <url>https://maven.geo-solutions.it</url>
         </repository>
+        -->
 
 				<!-- Hibernate Spatial -->
 <!--        <repository>
@@ -923,7 +923,7 @@
         <repository>
             <id>spring-release</id>
             <name>Spring Portfolio Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -931,7 +931,7 @@
         <repository>
             <id>spring-external</id>
             <name>Spring Portfolio External Repository</name>
-            <url>http://maven.springframework.org/external</url>
+            <url>https://maven.springframework.org/external</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -947,24 +947,6 @@
             </snapshots>
         </repository>-->
 
-				<!-- OSGEO -->
-        <repository>
-            <id>boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>http://repo.boundlessgeo.com/main/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
- centralize commons-beanutils version management
- bump commons-beanutils version from 1.7.0 to 1.9.4
- do some cleanup to make `mvn install` actually succeed

close #143
close #144