### PR TITLE
#160 add layergroup to layer dropdown in rules UI

### DIFF
--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/view/RulesView.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/view/RulesView.java
@@ -346,13 +346,18 @@ public class RulesView extends View {
 							RuleDetailsInfoWidget ruleDetailsWidget = ruleDetailsTabItem
 									.getRuleDetailsWidget()
 									.getRuleDetailsInfo();
-
 							ruleDetailsWidget.bindModelData(result);
 
-							if (result.getType().equalsIgnoreCase("raster")) {
-								ruleDetailsWidget.disableCQLFilterButtons();
-							} else {
+							if (result.getType().equalsIgnoreCase("vector")) {
 								ruleDetailsWidget.enableCQLFilterButtons();
+							} else {
+								ruleDetailsWidget.disableCQLFilterButtons();
+							}
+
+							if (result.getType().equalsIgnoreCase("layergroup")) {
+								ruleDetailsWidget.disableStyleCombo();
+							} else {
+								ruleDetailsWidget.enableStyleCombo();
 							}
 
 							Dispatcher

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsInfoWidget.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsInfoWidget.java
@@ -230,10 +230,10 @@ public class RuleDetailsInfoWidget extends GeofenceFormBindingWidget<LayerDetail
 
         draw.setIcon(Resources.ICONS.drawFeature());
 
-        
+
         fp.add(fieldSet);
         ruleDetailsWidget.getToolBar().add(draw);
-        
+
         return fp;
     }
 
@@ -433,6 +433,15 @@ public class RuleDetailsInfoWidget extends GeofenceFormBindingWidget<LayerDetail
         nameMode.put(ClientCatalogMode.NAME_HIDE, ClientCatalogMode.HIDE);
         nameMode.put(ClientCatalogMode.NAME_MIXED, ClientCatalogMode.MIXED);
         nameMode.put(ClientCatalogMode.NAME_CHALLENGE, ClientCatalogMode.CHALLENGE);
+    }
+
+    public void enableStyleCombo(){
+        this.comboStyles.enable();
+    }
+
+
+    public void disableStyleCombo(){
+        this.comboStyles.disable();
     }
 
 }

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/WorkspacesManagerServiceImpl.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/WorkspacesManagerServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 
+import it.geosolutions.geoserver.rest.decoder.*;
 import org.geoserver.geofence.core.model.LayerDetails;
 import org.geoserver.geofence.gui.client.ApplicationException;
 import org.geoserver.geofence.gui.client.configuration.WorkspaceConfigOpts;
@@ -26,13 +27,6 @@ import org.geoserver.geofence.gui.server.service.IWorkspacesManagerService;
 import org.geoserver.geofence.gui.service.GeofenceRemoteService;
 import org.geoserver.geofence.services.exception.NotFoundServiceEx;
 import it.geosolutions.geoserver.rest.GeoServerRESTReader;
-import it.geosolutions.geoserver.rest.decoder.RESTAbstractList;
-import it.geosolutions.geoserver.rest.decoder.RESTCoverageList;
-import it.geosolutions.geoserver.rest.decoder.RESTCoverageStoreList;
-import it.geosolutions.geoserver.rest.decoder.RESTFeatureTypeList;
-import it.geosolutions.geoserver.rest.decoder.RESTLayer;
-import it.geosolutions.geoserver.rest.decoder.RESTStyleList;
-import it.geosolutions.geoserver.rest.decoder.RESTWorkspaceList;
 import it.geosolutions.geoserver.rest.decoder.RESTWorkspaceList.RESTShortWorkspace;
 import it.geosolutions.geoserver.rest.decoder.utils.NameLinkElem;
 import java.util.SortedSet;
@@ -151,10 +145,15 @@ public class WorkspacesManagerServiceImpl implements IWorkspacesManagerService
 
                     if (workspace.equals("*")) { // load all layers
                         RESTAbstractList<NameLinkElem> layers = gsreader.getLayers();
+                        RESTAbstractList<NameLinkElem> layersGroups=gsreader.getLayerGroups();
                     	if (layers != null)
                     		for (NameLinkElem layerLink : layers) {
                     			sortedLayerNames.add(layerLink.getName());
                     		}
+                        if (layersGroups != null)
+                            for (NameLinkElem layerLink : layersGroups) {
+                                sortedLayerNames.add(layerLink.getName());
+                            }
                     } else {
 
                         if(StringUtils.isBlank(workspace))
@@ -190,6 +189,13 @@ public class WorkspacesManagerServiceImpl implements IWorkspacesManagerService
             RESTCoverageList coverages = reader.getCoverages(workspace, csName.getName());
             for (NameLinkElem coverage : coverages) {
                 layerNames.add(coverage.getName());
+            }
+        }
+
+        RESTLayerGroupList groupList = reader.getLayerGroups(workspace);
+        if (groupList!=null){
+            for (NameLinkElem lg:groupList){
+                layerNames.add(lg.getName());
             }
         }
 
@@ -275,5 +281,7 @@ public class WorkspacesManagerServiceImpl implements IWorkspacesManagerService
 
         return layerStyles;
     }
+
+
 
 }


### PR DESCRIPTION
This pr add layerGroups to the layer list in the dropdown of the rule configuration UI.

Styles selection and cql filters are disabled in the details view.