### PR TITLE
#161 Preserve the SRID of allowed area when retrieving it through AccessInfo

### DIFF
--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/view/RulesView.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/view/RulesView.java
@@ -818,7 +818,11 @@ public class RulesView extends View {
 						.getRuleDetailsWidget().getRuleDetailsInfo();
 
                 // ETJ: FIXME
-				ruleDetailsInfoWidget.getAllowedArea().setValue("SRID=4326;" + area);
+				String areaWithSRID;
+				if (area.indexOf("SRID=")==-1)
+					areaWithSRID="SRID=4326;" + area;
+				else areaWithSRID=area;
+				ruleDetailsInfoWidget.getAllowedArea().setValue(areaWithSRID);
 				
 				rulesManagerServiceRemote.getLayerDetailsInfo(rule,
                         new AsyncCallback<LayerDetailsInfo>() {

--- a/src/services/core/services-impl/pom.xml
+++ b/src/services/core/services-impl/pom.xml
@@ -89,6 +89,22 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
 <!--
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
@@ -148,8 +148,13 @@ public class AccessInfoInternal implements Serializable {
         ret.setAttributes(attributes == null ? null : new HashSet<LayerAttribute>(attributes));
         ret.setCqlFilterRead(cqlFilterRead);
         ret.setCqlFilterWrite(cqlFilterWrite);
-        if(area != null)
-            ret.setAreaWkt(area.toText());
+        if(area != null) {
+            String txtArea = area.toText();
+            if (area.getSRID()!=0){
+                txtArea="SRID="+area.getSRID()+";"+txtArea;
+            }
+            ret.setAreaWkt(txtArea);
+        }
         ret.setCatalogMode(mapCatalogModeDTO(catalogMode));
 
         return ret;

--- a/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleAdminServiceImplTest.java
+++ b/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleAdminServiceImplTest.java
@@ -28,6 +28,10 @@ import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 /**
  *

--- a/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleAdminServiceImplTest.java
+++ b/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleAdminServiceImplTest.java
@@ -19,19 +19,13 @@ import org.geoserver.geofence.services.exception.BadRequestServiceEx;
 import org.geoserver.geofence.services.exception.NotFoundServiceEx;
 import java.util.Arrays;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.MultiPolygon;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
 
 /**
  *

--- a/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
+++ b/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
@@ -5,15 +5,11 @@
 
 package org.geoserver.geofence.services;
 
+import org.geoserver.geofence.core.model.*;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
-import org.geoserver.geofence.core.model.GSUser;
-import org.geoserver.geofence.core.model.IPAddressRange;
-import org.geoserver.geofence.core.model.LayerAttribute;
-import org.geoserver.geofence.core.model.LayerDetails;
-import org.geoserver.geofence.core.model.UserGroup;
-import org.geoserver.geofence.core.model.Rule;
 import org.geoserver.geofence.core.model.enums.AccessType;
 import org.geoserver.geofence.core.model.enums.GrantType;
 import org.geoserver.geofence.services.dto.AccessInfo;
@@ -26,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import org.geoserver.geofence.core.model.AdminRule;
+
 import org.geoserver.geofence.core.model.enums.AdminGrantType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -738,6 +734,55 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
         accessInfo = ruleReaderService.getAccessInfo(filter);
         assertEquals(GrantType.ALLOW, accessInfo.getGrant());
         assertTrue(accessInfo.getAdminRights());
+    }
+
+    @Test
+    public void testRuleLimitsAllowedAreaSRIDIsPreserved() throws NotFoundServiceEx, ParseException {
+        // test that the original SRID is present in the allowedArea wkt representation,
+        // when retrieving it from the AccessInfo object
+        Long id =null;
+        Long id2=null;
+        try {
+            {
+                Rule r1 = new Rule(10, null, null, null, null, "s1", "r1", "w1", "l1", GrantType.LIMIT);
+                ruleAdminService.insert(r1);
+                id = r1.getId();
+            }
+
+            {
+                Rule r2 = new Rule(11, null, null, null, null, "s1", "r1", "w1", "l1", GrantType.ALLOW);
+                id2 = ruleAdminService.insert(r2);
+            }
+
+            // save limits and check it has been saved
+            {
+                RuleLimits limits = new RuleLimits();
+                String wkt = "MULTIPOLYGON(((0.0016139656066815888 -0.0006386457758059581,0.0019599705696027314 -0.0006386457758059581,0.0019599705696027314 -0.0008854090051601674,0.0016139656066815888 -0.0008854090051601674,0.0016139656066815888 -0.0006386457758059581)))";
+                Geometry allowedArea = new WKTReader().read(wkt);
+                allowedArea.setSRID(3857);
+                limits.setAllowedArea((MultiPolygon) allowedArea);
+                ruleAdminService.setLimits(id, limits);
+            }
+
+            {
+                RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+                filter.setWorkspace("w1");
+                filter.setService("s1");
+                filter.setRequest("r1");
+                filter.setLayer("l1");
+                AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+                String[] wktAr = accessInfo.getAreaWkt().split(";");
+                assertEquals("SRID=3857", wktAr[0]);
+
+            }
+        } finally {
+
+            if(id!=null)
+                ruleAdminService.delete(id);
+            if (id2!=null)
+                ruleAdminService.delete(id2);
+
+        }
     }
 
 }

--- a/src/services/modules/rest/impl/src/test/java/org/geoserver/geofence/services/rest/impl/RESTBaseTest.java
+++ b/src/services/modules/rest/impl/src/test/java/org/geoserver/geofence/services/rest/impl/RESTBaseTest.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.geofence.services.rest.impl;
 
+import org.geoserver.geofence.services.RuleAdminService;
 import org.geoserver.geofence.services.dto.ShortGroup;
 import org.geoserver.geofence.services.rest.RESTRuleService;
 import org.geoserver.geofence.services.rest.RESTUserGroupService;

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -709,7 +709,7 @@
             <dependency>
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
-                <version>1.15.1</version>
+                <version>1.17.1</version>
             </dependency>
 
 		    <!-- =========================================================== -->


### PR DESCRIPTION
- Ensure that the SRID is included in the WKT representation of allowedArea, when the AccessInfo object is built from the rule.
- Fix a conflict between JTS versions.