### PR TITLE
#163 Clip allowed area filter

### DIFF
--- a/doc/setup/sql/002_create_schema_oracle.sql
+++ b/doc/setup/sql/002_create_schema_oracle.sql
@@ -44,6 +44,7 @@
     create table gr_layer_details (
         id number(19,0) not null,
         area MDSYS.SDO_GEOMETRY,
+        spatial_filter_type varchar2(255,char),
         cqlFilterRead varchar2(4000 char),
         cqlFilterWrite varchar2(4000 char),
         defaultStyle varchar2(255 char),
@@ -92,6 +93,7 @@
     create table gr_rule_limits (
         id number(19,0) not null,
         area MDSYS.SDO_GEOMETRY,
+        spatial_filter_type varchar2(255,char),
         rule_id number(19,0) not null,
         primary key (id),
         unique (rule_id)

--- a/doc/setup/sql/002_create_schema_oracle.sql
+++ b/doc/setup/sql/002_create_schema_oracle.sql
@@ -44,7 +44,7 @@
     create table gr_layer_details (
         id number(19,0) not null,
         area MDSYS.SDO_GEOMETRY,
-        spatial_filter_type varchar2(255,char),
+        spatial_filter_type varchar2(16 char),
         cqlFilterRead varchar2(4000 char),
         cqlFilterWrite varchar2(4000 char),
         defaultStyle varchar2(255 char),
@@ -93,7 +93,7 @@
     create table gr_rule_limits (
         id number(19,0) not null,
         area MDSYS.SDO_GEOMETRY,
-        spatial_filter_type varchar2(255,char),
+        spatial_filter_type varchar2(16 char),
         rule_id number(19,0) not null,
         primary key (id),
         unique (rule_id)

--- a/doc/setup/sql/002_create_schema_postgres.sql
+++ b/doc/setup/sql/002_create_schema_postgres.sql
@@ -72,7 +72,7 @@ CREATE TABLE gf_layer_attributes (
 CREATE TABLE gf_layer_details (
     id bigint NOT NULL,
     area geometry,
-    spatial_filter_type character varying(255),
+    spatial_filter_type character varying(16),
     catalog_mode character varying(255),
     cqlfilterread character varying(4000),
     cqlfilterwrite character varying(4000),
@@ -105,7 +105,7 @@ CREATE TABLE gf_rule (
 CREATE TABLE gf_rule_limits (
     id bigint NOT NULL,
     area geometry,
-    spatial_filter_type character varying(255),
+    spatial_filter_type character varying(16),
     catalog_mode character varying(255),
     rule_id bigint NOT NULL
 );

--- a/doc/setup/sql/002_create_schema_postgres.sql
+++ b/doc/setup/sql/002_create_schema_postgres.sql
@@ -72,6 +72,7 @@ CREATE TABLE gf_layer_attributes (
 CREATE TABLE gf_layer_details (
     id bigint NOT NULL,
     area geometry,
+    spatial_filter_type character varying(255),
     catalog_mode character varying(255),
     cqlfilterread character varying(4000),
     cqlfilterwrite character varying(4000),
@@ -104,6 +105,7 @@ CREATE TABLE gf_rule (
 CREATE TABLE gf_rule_limits (
     id bigint NOT NULL,
     area geometry,
+    spatial_filter_type character varying(255),
     catalog_mode character varying(255),
     rule_id bigint NOT NULL
 );

--- a/doc/setup/sql/003_update_schema_oracle.sql
+++ b/doc/setup/sql/003_update_schema_oracle.sql
@@ -1,0 +1,7 @@
+    alter table gr_layer_details add (
+        spatial_filter_type varchar2(255,char) default 'INTERSECTS'
+    );
+
+    alter table gr_rule_limits add (
+        spatial_filter_type varchar2(255,char) default 'INTERSECTS'
+    );

--- a/doc/setup/sql/003_update_schema_oracle.sql
+++ b/doc/setup/sql/003_update_schema_oracle.sql
@@ -1,7 +1,7 @@
     alter table gr_layer_details add (
-        spatial_filter_type varchar2(255,char) default 'INTERSECTS'
+        spatial_filter_type varchar2(16 char) default 'INTERSECT'
     );
 
     alter table gr_rule_limits add (
-        spatial_filter_type varchar2(255,char) default 'INTERSECTS'
+        spatial_filter_type varchar2(16 char) default 'INTERSECT'
     );

--- a/doc/setup/sql/003_update_schema_postgres.sql
+++ b/doc/setup/sql/003_update_schema_postgres.sql
@@ -1,0 +1,3 @@
+ALTER TABLE gf_layer_details ADD COLUMN spatial_filter_type character varying(255) DEFAULT 'INTERSECTS';
+
+ALTER TABLE gf_rule_limits ADD COLUMN spatial_filter_type character varying(255) DEFAULT 'INTERSECTS';

--- a/doc/setup/sql/003_update_schema_postgres.sql
+++ b/doc/setup/sql/003_update_schema_postgres.sql
@@ -1,3 +1,3 @@
-ALTER TABLE gf_layer_details ADD COLUMN spatial_filter_type character varying(255) DEFAULT 'INTERSECTS';
+ALTER TABLE gf_layer_details ADD COLUMN spatial_filter_type character varying(16) DEFAULT 'INTERSECT';
 
-ALTER TABLE gf_rule_limits ADD COLUMN spatial_filter_type character varying(255) DEFAULT 'INTERSECTS';
+ALTER TABLE gf_rule_limits ADD COLUMN spatial_filter_type character varying(16) DEFAULT 'INTERSECT';

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/view/RulesView.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/view/RulesView.java
@@ -350,14 +350,16 @@ public class RulesView extends View {
 
 							if (result.getType().equalsIgnoreCase("vector")) {
 								ruleDetailsWidget.enableCQLFilterButtons();
+								ruleDetailsWidget.enableStyleCombo();
+								ruleDetailsWidget.enableSpatialFilterType();
+							} else if (result.getType().equalsIgnoreCase("layergroup")){
+								ruleDetailsWidget.disableCQLFilterButtons();
+								ruleDetailsWidget.disableStyleCombo();
+								ruleDetailsWidget.enableSpatialFilterType();
 							} else {
 								ruleDetailsWidget.disableCQLFilterButtons();
-							}
-
-							if (result.getType().equalsIgnoreCase("layergroup")) {
-								ruleDetailsWidget.disableStyleCombo();
-							} else {
 								ruleDetailsWidget.enableStyleCombo();
+								ruleDetailsWidget.disableSpatialFilterType();
 							}
 
 							Dispatcher

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/dialog/RuleDetailsEditDialog.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/dialog/RuleDetailsEditDialog.java
@@ -88,7 +88,7 @@ public class RuleDetailsEditDialog extends Dialog
         setClosable(true);
         setModal(true);
         setWidth(700);
-        setHeight(427);
+        setHeight(450);
         setId(I18nProvider.getMessages().ruleDialogId());
 
         add(this.getTabWidget());

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsInfoWidget.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsInfoWidget.java
@@ -447,7 +447,7 @@ public class RuleDetailsInfoWidget extends GeofenceFormBindingWidget<LayerDetail
         ListStore<ClientSpatialFilterType> ret = new ListStore<ClientSpatialFilterType>();
         List<ClientSpatialFilterType> list = new ArrayList<ClientSpatialFilterType>();
 
-        list.add(ClientSpatialFilterType.INTERSECTS);
+        list.add(ClientSpatialFilterType.INTERSECT);
         list.add(ClientSpatialFilterType.CLIP);
 
         ret.add(list);
@@ -490,7 +490,23 @@ public class RuleDetailsInfoWidget extends GeofenceFormBindingWidget<LayerDetail
 
     private void initSpatialFilterTypeMap() {
         spatialFilterTypeMap.put(ClientSpatialFilterType.CLIP_NAME, ClientSpatialFilterType.CLIP);
-        spatialFilterTypeMap.put(ClientSpatialFilterType.INTERSECTS_NAME, ClientSpatialFilterType.INTERSECTS);
+        spatialFilterTypeMap.put(ClientSpatialFilterType.INTERSECT_NAME, ClientSpatialFilterType.INTERSECT);
+    }
+
+    /**
+     * Disable spatialFilterType combo.
+     */
+    public void disableSpatialFilterType()
+    {
+        this.spatialFilterTypeBox.disable();
+    }
+
+    /**
+     * Enable spatialFilterType combo.
+     */
+    public void enableSpatialFilterType()
+    {
+        this.spatialFilterTypeBox.enable();
     }
 
 }

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsTabItem.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsTabItem.java
@@ -65,6 +65,8 @@ public class RuleDetailsTabItem extends TabItem {
 		add(getRuleDetailsWidget());
 
 		setScrollMode(Scroll.NONE);
+		Dispatcher.forwardEvent(
+				GeofenceEvents.LOAD_LAYER_DETAILS, theRule);
 
 			this.addListener(Events.Select, new Listener<BaseEvent>() {
 

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsWidget.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleDetailsWidget.java
@@ -64,16 +64,16 @@ public class RuleDetailsWidget extends ContentPanel
 
         setHeaderVisible(false);
         setFrame(true);
-        setHeight(330);
+        setHeight(350);
         setWidth(690);
         setLayout(new FitLayout());
 
         ruleDetailsInfo = new RuleDetailsInfoWidget(this.theRule, workspacesService, this);
         add(ruleDetailsInfo.getFormPanel());
 
+        ruleDetailsInfo.getModelData();
         ruleDetailsGrid = new RuleDetailsGridWidget(this.theRule, workspacesService, this);
         add(ruleDetailsGrid.getGrid());
-
         super.setMonitorWindowResize(true);
 
         setScrollMode(Scroll.AUTOY);

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleLimitsInfoWidget.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleLimitsInfoWidget.java
@@ -332,7 +332,7 @@ public class RuleLimitsInfoWidget extends GeofenceFormBindingWidget<LayerLimitsI
         ListStore<ClientSpatialFilterType> ret = new ListStore<ClientSpatialFilterType>();
         List<ClientSpatialFilterType> list = new ArrayList<ClientSpatialFilterType>();
 
-        list.add(ClientSpatialFilterType.INTERSECTS);
+        list.add(ClientSpatialFilterType.INTERSECT);
         list.add(ClientSpatialFilterType.CLIP);
 
         ret.add(list);
@@ -350,7 +350,7 @@ public class RuleLimitsInfoWidget extends GeofenceFormBindingWidget<LayerLimitsI
 
     private void initSpatialFilterTypeMap() {
         spatialFilterTypeMap.put(ClientSpatialFilterType.CLIP_NAME, ClientSpatialFilterType.CLIP);
-        spatialFilterTypeMap.put(ClientSpatialFilterType.INTERSECTS_NAME, ClientSpatialFilterType.INTERSECTS);
+        spatialFilterTypeMap.put(ClientSpatialFilterType.INTERSECT_NAME, ClientSpatialFilterType.INTERSECT);
     }
 
 }

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleLimitsTabItem.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/client/widget/rule/detail/RuleLimitsTabItem.java
@@ -70,6 +70,7 @@ public class RuleLimitsTabItem extends TabItem {
 					if (ruleLimitsWidget.getRuleLimitsInfo().getModel() == null) {
 						Dispatcher.forwardEvent(
 								GeofenceEvents.LOAD_LAYER_LIMITS, theRule);
+						Dispatcher.forwardEvent(GeofenceEvents.LOAD_LAYER_DETAILS,theRule);
 					}
 				}
 

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/RulesManagerServiceImpl.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/RulesManagerServiceImpl.java
@@ -9,9 +9,8 @@ import org.geoserver.geofence.core.model.LayerAttribute;
 import org.geoserver.geofence.core.model.LayerDetails;
 import org.geoserver.geofence.core.model.RuleLimits;
 import org.geoserver.geofence.core.model.*;
+import org.geoserver.geofence.core.model.enums.*;
 import org.geoserver.geofence.core.model.enums.AccessType;
-import org.geoserver.geofence.core.model.enums.GrantType;
-import org.geoserver.geofence.core.model.enums.LayerType;
 import org.geoserver.geofence.gui.client.ApplicationException;
 import org.geoserver.geofence.gui.client.model.GSInstanceModel;
 import org.geoserver.geofence.gui.client.model.RuleModel;
@@ -47,7 +46,6 @@ import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.apache.commons.lang.StringUtils;
-import org.geoserver.geofence.core.model.enums.CatalogMode;
 import org.geoserver.geofence.services.util.IPUtils;
 import org.springframework.dao.DuplicateKeyException;
 

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/RulesManagerServiceImpl.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/RulesManagerServiceImpl.java
@@ -830,7 +830,7 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
     }
 
     private static ClientSpatialFilterType toClientSpatialFilterType(SpatialFilterType type) {
-        ClientSpatialFilterType csft = ClientSpatialFilterType.INTERSECTS;
+        ClientSpatialFilterType csft = ClientSpatialFilterType.INTERSECT;
 
         if (type!=null && type.name().equals(SpatialFilterType.CLIP.name()))
             csft = ClientSpatialFilterType.CLIP;
@@ -842,7 +842,7 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
         if (csft!=null && csft.getType().equals(ClientSpatialFilterType.CLIP_NAME))
             spatialFilterType=SpatialFilterType.CLIP;
         else
-            spatialFilterType=SpatialFilterType.INTERSECTS;
+            spatialFilterType=SpatialFilterType.INTERSECT;
 
         return spatialFilterType;
     }

--- a/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/RulesManagerServiceImpl.java
+++ b/src/gui/core/plugin/userui/src/main/java/org/geoserver/geofence/gui/server/service/impl/RulesManagerServiceImpl.java
@@ -8,17 +8,14 @@ import it.geosolutions.geoserver.rest.decoder.RESTLayerGroup;
 import org.geoserver.geofence.core.model.LayerAttribute;
 import org.geoserver.geofence.core.model.LayerDetails;
 import org.geoserver.geofence.core.model.RuleLimits;
+import org.geoserver.geofence.core.model.*;
 import org.geoserver.geofence.core.model.enums.AccessType;
 import org.geoserver.geofence.core.model.enums.GrantType;
 import org.geoserver.geofence.core.model.enums.LayerType;
 import org.geoserver.geofence.gui.client.ApplicationException;
 import org.geoserver.geofence.gui.client.model.GSInstanceModel;
 import org.geoserver.geofence.gui.client.model.RuleModel;
-import org.geoserver.geofence.gui.client.model.data.LayerAttribUI;
-import org.geoserver.geofence.gui.client.model.data.LayerCustomProps;
-import org.geoserver.geofence.gui.client.model.data.LayerDetailsInfo;
-import org.geoserver.geofence.gui.client.model.data.LayerLimitsInfo;
-import org.geoserver.geofence.gui.client.model.data.LayerStyle;
+import org.geoserver.geofence.gui.client.model.data.*;
 import org.geoserver.geofence.gui.client.model.data.rpc.RpcPageLoadResult;
 import org.geoserver.geofence.gui.server.service.IRulesManagerService;
 import org.geoserver.geofence.gui.service.GeofenceRemoteService;
@@ -50,11 +47,7 @@ import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.apache.commons.lang.StringUtils;
-import org.geoserver.geofence.core.model.GSInstance;
-import org.geoserver.geofence.core.model.IPAddressRange;
-import org.geoserver.geofence.core.model.Rule;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
-import org.geoserver.geofence.gui.client.model.data.ClientCatalogMode;
 import org.geoserver.geofence.services.util.IPUtils;
 import org.springframework.dao.DuplicateKeyException;
 
@@ -436,7 +429,6 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
                     layAttrUI.setName(attrFromGS.getName());
                     layAttrUI.setDataType(attrFromGS.getBinding());
                     layAttrUI.setAccessType("READWRITE");
-
                     layerAttributesDTO.add(layAttrUI);
                 }
 
@@ -688,6 +680,7 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
                 ClientCatalogMode ccm = toClientCM(layerDetails.getCatalogMode());
                 layerDetailsInfo.setCatalogMode(ccm);
 
+
                 MultiPolygon the_geom = null;
                 Geometry geometry = layerDetails.getArea();
 
@@ -698,14 +691,20 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
                     the_geom = new MultiPolygon(new Polygon[]{(Polygon) geometry}, factory);
                 }
 
+
                 if (the_geom != null) {
                     layerDetailsInfo.setAllowedArea(the_geom.toText());
                     layerDetailsInfo
                             .setSrid(String.valueOf(the_geom.getSRID()));
+
                 } else {
                     layerDetailsInfo.setAllowedArea(null);
                     layerDetailsInfo.setSrid(null);
                 }
+
+                ClientSpatialFilterType csft = toClientSpatialFilterType(layerDetails.getSpatialFilterType());
+
+                layerDetailsInfo.setSpatialFilterType(csft);
 
                 if (layerDetails.getType().equals(LayerType.RASTER)) {
                     layerDetailsInfo.setType("raster");
@@ -793,6 +792,9 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
             CatalogMode cm = fromClientCM(layerLimitsForm.getCatalogMode());
             ruleLimits.setCatalogMode(cm);
 
+            ClientSpatialFilterType csft= layerLimitsForm.getSpatialFilterType();
+            ruleLimits.setSpatialFilterType(fromClientSpatialFilterType(csft));
+
             geofenceRemoteService.getRuleAdminService().setLimits(ruleId,
                     ruleLimits);
 
@@ -827,6 +829,24 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
         }
 
         return ccm;
+    }
+
+    private static ClientSpatialFilterType toClientSpatialFilterType(SpatialFilterType type) {
+        ClientSpatialFilterType csft = ClientSpatialFilterType.INTERSECTS;
+
+        if (type!=null && type.name().equals(SpatialFilterType.CLIP.name()))
+            csft = ClientSpatialFilterType.CLIP;
+        return csft;
+    }
+
+    private static SpatialFilterType fromClientSpatialFilterType(ClientSpatialFilterType csft) {
+        SpatialFilterType spatialFilterType=null;
+        if (csft!=null && csft.getType().equals(ClientSpatialFilterType.CLIP_NAME))
+            spatialFilterType=SpatialFilterType.CLIP;
+        else
+            spatialFilterType=SpatialFilterType.INTERSECTS;
+
+        return spatialFilterType;
     }
 
     private static CatalogMode fromClientCM(ClientCatalogMode ccm) {
@@ -864,7 +884,7 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
                 layerLimitsInfo = new LayerLimitsInfo();
                 layerLimitsInfo.setRuleId(ruleId);
 
-                MultiPolygon the_geom = ruleLimits.getAllowedArea();
+                MultiPolygon the_geom = (MultiPolygon) ruleLimits.getAllowedArea();
 
                 if (the_geom != null) {
                     layerLimitsInfo.setAllowedArea(the_geom.toText());
@@ -873,6 +893,8 @@ public class RulesManagerServiceImpl implements IRulesManagerService {
                     layerLimitsInfo.setAllowedArea(null);
                     layerLimitsInfo.setSrid(null);
                 }
+
+                layerLimitsInfo.setSpatialFilterType(toClientSpatialFilterType(ruleLimits.getSpatialFilterType()));
 
                 ClientCatalogMode ccm = toClientCM(ruleLimits.getCatalogMode());
                 layerLimitsInfo.setCatalogMode(ccm);

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/BeanKeyValue.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/BeanKeyValue.java
@@ -110,7 +110,9 @@ public enum BeanKeyValue {
     
     LAYER_ALLOWED_AREA_SRID("layer_allowed_area_srid"),
     
-    RULE_ALLOWED_AREA_SRID("rule_allowed_area_srid");
+    RULE_ALLOWED_AREA_SRID("rule_allowed_area_srid"),
+
+    SPATIAL_FILTER_TYPE("spatialFilterType");
     
     
     /** The value. */

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/ClientSpatialFilterType.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/ClientSpatialFilterType.java
@@ -13,10 +13,10 @@ public class ClientSpatialFilterType extends BeanModel implements IsSerializable
 
     private static final long serialVersionUID = 545243241879482276L;
 
-    public static String INTERSECTS_NAME="INTERSECTS";
+    public static String INTERSECT_NAME ="INTERSECT";
     public static String CLIP_NAME="CLIP";
 
-    public static ClientSpatialFilterType INTERSECTS = new ClientSpatialFilterType(INTERSECTS_NAME);
+    public static ClientSpatialFilterType INTERSECT = new ClientSpatialFilterType(INTERSECT_NAME);
 
     public static ClientSpatialFilterType CLIP = new ClientSpatialFilterType(CLIP_NAME);
 

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/ClientSpatialFilterType.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/ClientSpatialFilterType.java
@@ -1,0 +1,116 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.gui.client.model.data;
+
+import com.extjs.gxt.ui.client.data.BeanModel;
+import com.google.gwt.user.client.rpc.IsSerializable;
+import org.geoserver.geofence.gui.client.model.BeanKeyValue;
+
+public class ClientSpatialFilterType extends BeanModel implements IsSerializable {
+
+
+    private static final long serialVersionUID = 545243241879482276L;
+
+    public static String INTERSECTS_NAME="INTERSECTS";
+    public static String CLIP_NAME="CLIP";
+
+    public static ClientSpatialFilterType INTERSECTS = new ClientSpatialFilterType(INTERSECTS_NAME);
+
+    public static ClientSpatialFilterType CLIP = new ClientSpatialFilterType(CLIP_NAME);
+
+    /** The type. */
+    private String type;
+
+
+    protected ClientSpatialFilterType(String type)
+    {
+        setType(type);
+    }
+
+    /**
+     * Instantiates a new type.
+     */
+    public ClientSpatialFilterType() {
+
+    }
+
+    /**
+     * Sets the type.
+     *
+     * @param type the new type
+     */
+    public void setType(String type)
+    {
+        this.type = type;
+        set(BeanKeyValue.SPATIAL_FILTER_TYPE.getValue(), this.type);
+    }
+
+
+    public String getType()
+    {
+        return type;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = (prime * result) + ((type == null) ? 0 : type.hashCode());
+
+        return result;
+    }
+
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+        {
+            return true;
+        }
+        if (obj == null)
+        {
+            return false;
+        }
+        if (!(obj instanceof AccessType))
+        {
+            return false;
+        }
+
+        AccessType other = (AccessType) obj;
+        if (type == null)
+        {
+            if (other.getType() != null)
+            {
+                return false;
+            }
+        }
+        else if (!type.equals(other.getType()))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SpatialFilterType [");
+        if (type != null)
+        {
+            builder.append("type=").append(type).append(", ");
+        }
+        builder.append("]");
+
+        return builder.toString();
+    }
+}

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerDetailsInfo.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerDetailsInfo.java
@@ -8,7 +8,6 @@ package org.geoserver.geofence.gui.client.model.data;
 import com.extjs.gxt.ui.client.data.BeanModel;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
-import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.geoserver.geofence.gui.client.model.BeanKeyValue;
 
 

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerDetailsInfo.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerDetailsInfo.java
@@ -8,6 +8,7 @@ package org.geoserver.geofence.gui.client.model.data;
 import com.extjs.gxt.ui.client.data.BeanModel;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
+import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.geoserver.geofence.gui.client.model.BeanKeyValue;
 
 
@@ -36,6 +37,8 @@ public class LayerDetailsInfo extends BeanModel implements IsSerializable
     private String allowedArea;
 
     private String srid;
+
+    private ClientSpatialFilterType spatialFilterType;
 
     private ClientCatalogMode catalogMode;
 
@@ -175,6 +178,15 @@ public class LayerDetailsInfo extends BeanModel implements IsSerializable
     public void setCatalogMode(ClientCatalogMode catalogMode) {
         this.catalogMode = catalogMode;
         set(BeanKeyValue.CATALOG_MODE.getValue(), this.catalogMode);
+    }
+
+    public ClientSpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(ClientSpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
+        set(BeanKeyValue.SPATIAL_FILTER_TYPE.getValue(), this.spatialFilterType);
     }
 
 

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerLimitsInfo.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerLimitsInfo.java
@@ -8,7 +8,6 @@ package org.geoserver.geofence.gui.client.model.data;
 import com.extjs.gxt.ui.client.data.BeanModel;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
-import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.geoserver.geofence.gui.client.model.BeanKeyValue;
 
 

--- a/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerLimitsInfo.java
+++ b/src/gui/core/resources/src/main/java/org/geoserver/geofence/gui/client/model/data/LayerLimitsInfo.java
@@ -8,6 +8,7 @@ package org.geoserver.geofence.gui.client.model.data;
 import com.extjs.gxt.ui.client.data.BeanModel;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
+import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.geoserver.geofence.gui.client.model.BeanKeyValue;
 
 
@@ -30,6 +31,8 @@ public class LayerLimitsInfo extends BeanModel implements IsSerializable
     private String srid;
 
     private ClientCatalogMode catalogMode;
+
+    private ClientSpatialFilterType spatialFilterType;
 
 
     /**
@@ -97,6 +100,15 @@ public class LayerLimitsInfo extends BeanModel implements IsSerializable
     public void setCatalogMode(ClientCatalogMode catalogMode) {
         this.catalogMode = catalogMode;
         set(BeanKeyValue.CATALOG_MODE.getValue(), catalogMode);
+    }
+
+    public ClientSpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(ClientSpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
+        set(BeanKeyValue.SPATIAL_FILTER_TYPE.getValue(),spatialFilterType);
     }
 
     /* (non-Javadoc)

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/LayerDetails.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/LayerDetails.java
@@ -75,6 +75,10 @@ public class LayerDetails implements Serializable {
 	@Column(name = "area")
 	private MultiPolygon area;
 
+	@Enumerated(EnumType.STRING)
+    @Column(name="spatial_filter_type",nullable = true)
+	private SpatialFilterType spatialFilterType;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "catalog_mode", nullable = true)
     private CatalogMode catalogMode;
@@ -185,7 +189,15 @@ public class LayerDetails implements Serializable {
 
     public void setType(LayerType type) {
         this.type = type;
-    }    
+    }
+
+    public SpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(SpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
+    }
 
     @Override
     public String toString() {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/LayerDetails.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/LayerDetails.java
@@ -193,7 +193,7 @@ public class LayerDetails implements Serializable {
     }
 
     public SpatialFilterType getSpatialFilterType() {
-        return spatialFilterType!=null?spatialFilterType:SpatialFilterType.INTERSECTS;
+        return spatialFilterType!=null?spatialFilterType:SpatialFilterType.INTERSECT;
     }
 
     public void setSpatialFilterType(SpatialFilterType spatialFilterType) {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/LayerDetails.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/LayerDetails.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.geofence.core.model;
 
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.geoserver.geofence.core.model.adapter.MultiPolygonAdapter;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
@@ -192,7 +193,7 @@ public class LayerDetails implements Serializable {
     }
 
     public SpatialFilterType getSpatialFilterType() {
-        return spatialFilterType;
+        return spatialFilterType!=null?spatialFilterType:SpatialFilterType.INTERSECTS;
     }
 
     public void setSpatialFilterType(SpatialFilterType spatialFilterType) {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/RuleLimits.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/RuleLimits.java
@@ -60,6 +60,10 @@ public class RuleLimits implements Serializable {
     private MultiPolygon allowedArea;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "spatial_filter_type", nullable = true)
+    private SpatialFilterType spatialFilterType;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "catalog_mode", nullable = true)
     private CatalogMode catalogMode;
 
@@ -78,6 +82,14 @@ public class RuleLimits implements Serializable {
 
     public void setCatalogMode(CatalogMode catalogMode) {
         this.catalogMode = catalogMode;
+    }
+
+    public SpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(SpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
     }
 
     public Long getId() {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/RuleLimits.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/RuleLimits.java
@@ -86,7 +86,7 @@ public class RuleLimits implements Serializable {
     }
 
     public SpatialFilterType getSpatialFilterType() {
-        return spatialFilterType!=null?spatialFilterType:SpatialFilterType.INTERSECTS;
+        return spatialFilterType!=null?spatialFilterType:SpatialFilterType.INTERSECT;
     }
 
     public void setSpatialFilterType(SpatialFilterType spatialFilterType) {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/RuleLimits.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/RuleLimits.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.geoserver.geofence.core.model.adapter.MultiPolygonAdapter;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
 import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Check;
@@ -85,7 +86,7 @@ public class RuleLimits implements Serializable {
     }
 
     public SpatialFilterType getSpatialFilterType() {
-        return spatialFilterType;
+        return spatialFilterType!=null?spatialFilterType:SpatialFilterType.INTERSECTS;
     }
 
     public void setSpatialFilterType(SpatialFilterType spatialFilterType) {

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/SpatialFilterType.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/SpatialFilterType.java
@@ -1,0 +1,9 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.core.model;
+
+public enum SpatialFilterType {
+    INTERSECTS,CLIP
+}

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/enums/SpatialFilterType.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/enums/SpatialFilterType.java
@@ -5,5 +5,5 @@
 package org.geoserver.geofence.core.model.enums;
 
 public enum SpatialFilterType {
-    INTERSECTS,CLIP
+    INTERSECT,CLIP
 }

--- a/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/enums/SpatialFilterType.java
+++ b/src/services/core/model/src/main/java/org/geoserver/geofence/core/model/enums/SpatialFilterType.java
@@ -2,7 +2,7 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.geofence.core.model;
+package org.geoserver.geofence.core.model.enums;
 
 public enum SpatialFilterType {
     INTERSECTS,CLIP

--- a/src/services/core/persistence/src/test/java/org/geoserver/geofence/core/dao/RuleDAOTest.java
+++ b/src/services/core/persistence/src/test/java/org/geoserver/geofence/core/dao/RuleDAOTest.java
@@ -6,14 +6,11 @@
 package org.geoserver.geofence.core.dao;
 
 import com.googlecode.genericdao.search.Search;
+import org.geoserver.geofence.core.model.*;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
 import static org.geoserver.geofence.core.dao.BaseDAOTest.ruleDAO;
 import org.geoserver.geofence.core.dao.util.SearchUtil;
-import org.geoserver.geofence.core.model.GSUser;
-import org.geoserver.geofence.core.model.IPAddressRange;
-import org.geoserver.geofence.core.model.LayerAttribute;
-import org.geoserver.geofence.core.model.LayerDetails;
-import org.geoserver.geofence.core.model.Rule;
 import org.geoserver.geofence.core.model.enums.AccessType;
 import org.geoserver.geofence.core.model.enums.GrantType;
 import org.geoserver.geofence.core.model.enums.InsertPosition;
@@ -221,6 +218,53 @@ public class RuleDAOTest extends BaseDAOTest {
             }
         }
 
+    }
+
+    @Test
+    public void testPersistLayerDetailsWithSpatailFilterType() throws Exception {
+
+        long rid = createRule().getId();
+
+        // add details
+        {
+            Rule loaded = ruleDAO.find(rid);
+            assertNotNull("Can't retrieve rule", loaded);
+
+            assertNull(loaded.getLayerDetails());
+
+            LayerDetails details = new LayerDetails();
+            details.setRule(loaded);
+            details.setDefaultStyle("default");
+            details.getAttributes().add(new LayerAttribute("a1", AccessType.NONE));
+            details.getAttributes().add(new LayerAttribute("a2", AccessType.READONLY));
+            details.getAttributes().add(new LayerAttribute("a3", AccessType.READWRITE));
+            details.getAttributes().add(new LayerAttribute("a4", AccessType.READWRITE));
+
+            GeometryFactory factory = new GeometryFactory();
+            details.setArea(factory.createMultiPolygon());
+            details.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+
+            detailsDAO.persist(details);
+        }
+
+        // check everything's fine
+        {
+            Rule loaded2 = ruleDAO.find(rid);
+            assertNotNull("Can't retrieve rule", loaded2);
+            LayerDetails details = loaded2.getLayerDetails();
+            assertNotNull(details);
+
+            assertEquals(SpatialFilterType.INTERSECTS, details.getSpatialFilterType());
+        }
+
+        // try removing the details
+        {
+            Rule loaded2 = ruleDAO.find(rid);
+            LayerDetails details = loaded2.getLayerDetails();
+            assertNotNull(details);
+
+            detailsDAO.remove(details);
+        }
     }
 
 

--- a/src/services/core/persistence/src/test/java/org/geoserver/geofence/core/dao/RuleDAOTest.java
+++ b/src/services/core/persistence/src/test/java/org/geoserver/geofence/core/dao/RuleDAOTest.java
@@ -6,7 +6,11 @@
 package org.geoserver.geofence.core.dao;
 
 import com.googlecode.genericdao.search.Search;
-import org.geoserver.geofence.core.model.*;
+import org.geoserver.geofence.core.model.Rule;
+import org.geoserver.geofence.core.model.LayerAttribute;
+import org.geoserver.geofence.core.model.LayerDetails;
+import org.geoserver.geofence.core.model.IPAddressRange;
+import org.geoserver.geofence.core.model.GSUser;
 import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -15,7 +19,6 @@ import org.geoserver.geofence.core.model.enums.AccessType;
 import org.geoserver.geofence.core.model.enums.GrantType;
 import org.geoserver.geofence.core.model.enums.InsertPosition;
 import java.util.List;
-
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -242,7 +245,7 @@ public class RuleDAOTest extends BaseDAOTest {
 
             GeometryFactory factory = new GeometryFactory();
             details.setArea(factory.createMultiPolygon());
-            details.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+            details.setSpatialFilterType(SpatialFilterType.INTERSECT);
 
             detailsDAO.persist(details);
         }
@@ -254,7 +257,7 @@ public class RuleDAOTest extends BaseDAOTest {
             LayerDetails details = loaded2.getLayerDetails();
             assertNotNull(details);
 
-            assertEquals(SpatialFilterType.INTERSECTS, details.getSpatialFilterType());
+            assertEquals(SpatialFilterType.INTERSECT, details.getSpatialFilterType());
         }
 
         // try removing the details

--- a/src/services/core/persistence/src/test/java/org/geoserver/geofence/core/dao/RuleDAOTest.java
+++ b/src/services/core/persistence/src/test/java/org/geoserver/geofence/core/dao/RuleDAOTest.java
@@ -7,9 +7,9 @@ package org.geoserver.geofence.core.dao;
 
 import com.googlecode.genericdao.search.Search;
 import org.geoserver.geofence.core.model.*;
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
-import static org.geoserver.geofence.core.dao.BaseDAOTest.ruleDAO;
 import org.geoserver.geofence.core.dao.util.SearchUtil;
 import org.geoserver.geofence.core.model.enums.AccessType;
 import org.geoserver.geofence.core.model.enums.GrantType;

--- a/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/dto/AccessInfo.java
+++ b/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/dto/AccessInfo.java
@@ -6,7 +6,6 @@
 package org.geoserver.geofence.services.dto;
 
 import org.geoserver.geofence.core.model.LayerAttribute;
-import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.geoserver.geofence.core.model.enums.GrantType;
 
 import java.io.Serializable;
@@ -39,7 +38,7 @@ public class AccessInfo implements Serializable {
 //    private Geometry area;
     private String areaWkt;
 
-    private SpatialFilterType spatialFilterType;
+    private String clipAreaWkt;
 
     private CatalogModeDTO catalogMode;
 
@@ -68,12 +67,12 @@ public class AccessInfo implements Serializable {
         this.areaWkt = areaWkt;
     }
 
-    public SpatialFilterType getSpatialFilterType() {
-        return spatialFilterType;
+    public String getClipAreaWkt() {
+        return clipAreaWkt;
     }
 
-    public void setSpatialFilterType(SpatialFilterType spatialFilterType) {
-        this.spatialFilterType = spatialFilterType;
+    public void setClipAreaWkt(String clipAreaWkt) {
+        this.clipAreaWkt = clipAreaWkt;
     }
 
     public Set<LayerAttribute> getAttributes() {

--- a/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/dto/AccessInfo.java
+++ b/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/dto/AccessInfo.java
@@ -6,6 +6,7 @@
 package org.geoserver.geofence.services.dto;
 
 import org.geoserver.geofence.core.model.LayerAttribute;
+import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.geoserver.geofence.core.model.enums.GrantType;
 
 import java.io.Serializable;
@@ -38,6 +39,8 @@ public class AccessInfo implements Serializable {
 //    private Geometry area;
     private String areaWkt;
 
+    private SpatialFilterType spatialFilterType;
+
     private CatalogModeDTO catalogMode;
 
     private String defaultStyle;
@@ -63,6 +66,14 @@ public class AccessInfo implements Serializable {
 
     public void setAreaWkt(String areaWkt) {
         this.areaWkt = areaWkt;
+    }
+
+    public SpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(SpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
     }
 
     public Set<LayerAttribute> getAttributes() {

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
@@ -8,7 +8,7 @@ package org.geoserver.geofence.services.util;
 import java.io.Serializable;
 import java.util.Set;
 
-import org.geoserver.geofence.core.model.SpatialFilterType;
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 import org.locationtech.jts.geom.Geometry;
 
 import org.geoserver.geofence.core.model.LayerAttribute;
@@ -47,6 +47,8 @@ public class AccessInfoInternal implements Serializable {
 
 //    private Geometry area;
     private Geometry area;
+
+    private Geometry clipArea;
 
     private SpatialFilterType spatialFilterType;
 
@@ -150,6 +152,14 @@ public class AccessInfoInternal implements Serializable {
         this.grant = grant;
     }
 
+    public Geometry getClipArea() {
+        return clipArea;
+    }
+
+    public void setClipArea(Geometry clipArea) {
+        this.clipArea = clipArea;
+    }
+
     public AccessInfo toAccessInfo() {
         AccessInfo ret = new AccessInfo();
 
@@ -166,10 +176,19 @@ public class AccessInfoInternal implements Serializable {
             }
             ret.setAreaWkt(txtArea);
         }
-        ret.setSpatialFilterType(spatialFilterType);
+        if (clipArea !=null){
+            ret.setClipAreaWkt(getClipArea(clipArea,area));
+        }
         ret.setCatalogMode(mapCatalogModeDTO(catalogMode));
 
         return ret;
+    }
+
+
+    private String getClipArea(Geometry clipArea,Geometry intersectArea){
+        if (intersectArea!=null && clipArea.overlaps(intersectArea))
+            return clipArea.difference(intersectArea).toText();
+        return clipArea.toText();
     }
 
     protected static CatalogModeDTO mapCatalogModeDTO(CatalogMode cm) {

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
@@ -177,7 +177,11 @@ public class AccessInfoInternal implements Serializable {
             ret.setAreaWkt(txtArea);
         }
         if (clipArea !=null){
-            ret.setClipAreaWkt(getClipArea(clipArea,area));
+            String clipAreaTxt=clipArea.toText();
+            if(clipArea.getSRID()!=0){
+                clipAreaTxt="SRID="+clipArea.getSRID()+";"+clipAreaTxt;
+            }
+            ret.setClipAreaWkt(clipAreaTxt);
         }
         ret.setCatalogMode(mapCatalogModeDTO(catalogMode));
 
@@ -185,11 +189,6 @@ public class AccessInfoInternal implements Serializable {
     }
 
 
-    private String getClipArea(Geometry clipArea,Geometry intersectArea){
-        if (intersectArea!=null && clipArea.overlaps(intersectArea))
-            return clipArea.difference(intersectArea).toText();
-        return clipArea.toText();
-    }
 
     protected static CatalogModeDTO mapCatalogModeDTO(CatalogMode cm) {
         if(cm == null)

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/util/AccessInfoInternal.java
@@ -8,6 +8,7 @@ package org.geoserver.geofence.services.util;
 import java.io.Serializable;
 import java.util.Set;
 
+import org.geoserver.geofence.core.model.SpatialFilterType;
 import org.locationtech.jts.geom.Geometry;
 
 import org.geoserver.geofence.core.model.LayerAttribute;
@@ -46,6 +47,8 @@ public class AccessInfoInternal implements Serializable {
 
 //    private Geometry area;
     private Geometry area;
+
+    private SpatialFilterType spatialFilterType;
 
     private CatalogMode catalogMode;
 
@@ -129,6 +132,14 @@ public class AccessInfoInternal implements Serializable {
         this.catalogMode = catalogMode;
     }
 
+    public SpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(SpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
+    }
+
     public GrantType getGrant() {
         return grant;
     }
@@ -155,6 +166,7 @@ public class AccessInfoInternal implements Serializable {
             }
             ret.setAreaWkt(txtArea);
         }
+        ret.setSpatialFilterType(spatialFilterType);
         ret.setCatalogMode(mapCatalogModeDTO(catalogMode));
 
         return ret;

--- a/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
+++ b/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
@@ -8,9 +8,7 @@ package org.geoserver.geofence.services;
 import org.geoserver.geofence.core.model.*;
 import org.locationtech.jts.geom.Geometry;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.geoserver.geofence.core.model.enums.*;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
@@ -853,50 +851,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         }
     }
-
-
-    public void testRuleWithSpatialFilterType() throws ParseException {
-
-        GSUser user = createUser("auth00");
-        long id=ruleAdminService.insert(new Rule(10, user.getName(), null, null, null,     "s1", "r1", "w1", "l1", GrantType.LIMIT));
-        RuleLimits limits = new RuleLimits();
-        limits.setSpatialFilterType(SpatialFilterType.CLIP);
-        limits.setCatalogMode(CatalogMode.HIDE);
-        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
-        MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
-        limits.setAllowedArea(area);
-        ruleAdminService.setLimits(id, limits);
-
-
-        long id2=ruleAdminService.insert(new Rule(11, user.getName(), "group12", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
-        RuleLimits limits2 = new RuleLimits();
-        limits2.setSpatialFilterType(SpatialFilterType.INTERSECTS);
-        limits2.setCatalogMode(CatalogMode.HIDE);
-        String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
-        MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
-        limits2.setAllowedArea(area2);
-        ruleAdminService.setLimits(id2, limits2);
-        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
-        filter.setWorkspace("w11");
-        filter.setLayer("l11");
-
-        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
-        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
-        assertFalse(accessInfo.getAdminRights());
-
-        // area in same group, the result should an itersection of the
-        // two allowed area as a clip geometry.
-
-        Geometry testArea=area.intersection(area2);
-        testArea.normalize();
-        assertNull(accessInfo.getAreaWkt());
-        assertNotNull(accessInfo.getClipAreaWkt());
-
-        Geometry resultArea= (new WKTReader().read(accessInfo.getClipAreaWkt()));
-        resultArea.normalize();
-        assertTrue(testArea.equalsExact(resultArea,10.0E-15));
-    }
-
+    
     public void testRuleSpatialFilterTypeClipSameGroup() throws ParseException {
 
         // test that when we have two rules referring to the same group
@@ -920,7 +875,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         long id2=ruleAdminService.insert(new Rule(11, user.getName(), "group12", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
         RuleLimits limits2 = new RuleLimits();
-        limits2.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits2.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits2.setCatalogMode(CatalogMode.HIDE);
         String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
         MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
@@ -962,7 +917,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
         ruleAdminService.insert(new Rule(9999, null, null, null, null,     "s11", "r11", "w11", "l11", GrantType.ALLOW));
         long id=ruleAdminService.insert(new Rule(13, user.getName(), "group13", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
         RuleLimits limits = new RuleLimits();
-        limits.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits.setCatalogMode(CatalogMode.HIDE);
         String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
         MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
@@ -972,7 +927,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         long id2=ruleAdminService.insert(new Rule(14, user.getName(), "group14", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
         RuleLimits limits2 = new RuleLimits();
-        limits2.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits2.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits2.setCatalogMode(CatalogMode.HIDE);
         String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
         MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
@@ -1015,7 +970,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         long id=ruleAdminService.insert(new Rule(15, null, "group22", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
         RuleLimits limits = new RuleLimits();
-        limits.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits.setCatalogMode(CatalogMode.HIDE);
         String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
         MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
@@ -1051,13 +1006,10 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
         intersects.normalize();
         assertTrue(intersects.equalsExact(area, 10.0E-15));
 
-        // Since the two areas overlap the result clip geometry should
-        // be the difference between the define clip and the intersects
-        Geometry clip=new WKTReader().read(accessInfo.getClipAreaWkt()).difference(intersects);
+        Geometry clip=new WKTReader().read(accessInfo.getClipAreaWkt());
         clip.normalize();
-        Geometry areaDifference=area2.difference(area);
-        areaDifference.normalize();
-        assertTrue(clip.equalsExact(areaDifference,10.0E-15));
+        area2.normalize();
+        assertTrue(clip.equalsExact(area2,10.0E-15));
     }
 
 
@@ -1080,7 +1032,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         long id=ruleAdminService.insert(new Rule(17, null, "group31", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
         RuleLimits limits = new RuleLimits();
-        limits.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits.setCatalogMode(CatalogMode.HIDE);
         String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
         MultiPolygon area=(MultiPolygon)reader.read(areaWKT);
@@ -1172,7 +1124,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         long id3=ruleAdminService.insert(new Rule(23,null, "group42", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
         RuleLimits limits3 = new RuleLimits();
-        limits3.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits3.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits3.setCatalogMode(CatalogMode.HIDE);
         String areaWKT3="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
         MultiPolygon area3=(MultiPolygon)reader.read(areaWKT3);
@@ -1182,7 +1134,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
 
         long id4=ruleAdminService.insert(new Rule(24,null, "group42", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
         RuleLimits limits4 = new RuleLimits();
-        limits4.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits4.setSpatialFilterType(SpatialFilterType.INTERSECT);
         limits4.setCatalogMode(CatalogMode.HIDE);
         String areaWKT4="MultiPolygon (((-1.30963636363636482 5.96118181818181991, 1.78181818181818175 4.84754545454545571, -0.90872727272727349 2.26390909090909132, -1.30963636363636482 5.96118181818181991)))";
         MultiPolygon area4=(MultiPolygon)reader.read(areaWKT4);
@@ -1213,9 +1165,9 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
         System.out.println(expectedIntersects.toString());
         assertTrue(expectedIntersects.equalsExact(intersects,10.0E-15));
 
-        Geometry clip=reader.read(accessInfo.getClipAreaWkt()).difference(intersects);
+        Geometry clip=reader.read(accessInfo.getClipAreaWkt());
         clip.normalize();
-        Geometry expectedClip=area2.intersection(area).difference(intersects);
+        Geometry expectedClip=area2.intersection(area);
         expectedClip.normalize();
         assertTrue(expectedClip.equalsExact(clip,10.0E-15));
 

--- a/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
+++ b/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
@@ -7,6 +7,8 @@ package org.geoserver.geofence.services;
 
 import org.geoserver.geofence.core.model.*;
 import org.locationtech.jts.geom.Geometry;
+import org.geoserver.geofence.core.model.enums.CatalogMode;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
@@ -790,9 +792,9 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
     public void testRuleLimitsAllowedAreaReprojectionWithDifferentSrid() throws NotFoundServiceEx, ParseException {
         // test that the original SRID is present in the allowedArea wkt representation,
         // when retrieving it from the AccessInfo object
-        Long id =null;
-        Long id2=null;
-        Long id3=null;
+        Long id = null;
+        Long id2 = null;
+        Long id3 = null;
         try {
             {
                 Rule r1 = new Rule(999, null, null, null, null, "s1", "r1", "w1", "l1", GrantType.ALLOW);
@@ -808,7 +810,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
             // save limits and check it has been saved
             {
                 RuleLimits limits = new RuleLimits();
-                String wkt="MultiPolygon (((1680529.71478682174347341 4849746.00902365241199732, 1682436.7076464940328151 4849731.7422441728413105, 1682446.21883281995542347 4849208.62699576932936907, 1680524.95919364970177412 4849279.96089325752109289, 1680529.71478682174347341 4849746.00902365241199732)))";
+                String wkt = "MultiPolygon (((1680529.71478682174347341 4849746.00902365241199732, 1682436.7076464940328151 4849731.7422441728413105, 1682446.21883281995542347 4849208.62699576932936907, 1680524.95919364970177412 4849279.96089325752109289, 1680529.71478682174347341 4849746.00902365241199732)))";
                 Geometry allowedArea = new WKTReader().read(wkt);
                 allowedArea.setSRID(3003);
                 limits.setAllowedArea((MultiPolygon) allowedArea);
@@ -823,7 +825,7 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
             // save limits and check it has been saved
             {
                 RuleLimits limits = new RuleLimits();
-                String wkt="MultiPolygon (((680588.67850254673976451 4850060.34823693986982107, 681482.71827003755606711 4850469.32878803834319115, 682633.56349697941914201 4849499.20374245755374432, 680588.67850254673976451 4850060.34823693986982107)))";
+                String wkt = "MultiPolygon (((680588.67850254673976451 4850060.34823693986982107, 681482.71827003755606711 4850469.32878803834319115, 682633.56349697941914201 4849499.20374245755374432, 680588.67850254673976451 4850060.34823693986982107)))";
                 Geometry allowedArea = new WKTReader().read(wkt);
                 allowedArea.setSRID(23032);
                 limits.setAllowedArea((MultiPolygon) allowedArea);
@@ -843,14 +845,36 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
             }
         } finally {
 
-            if(id!=null)
+            if (id != null)
                 ruleAdminService.delete(id);
-            if (id2!=null)
+            if (id2 != null)
                 ruleAdminService.delete(id2);
-            if(id3!=null)
+            if (id3 != null)
                 ruleAdminService.delete(id3);
 
         }
+    }
+
+
+    public void testRuleWithSpatialFilterType() {
+
+        GSUser user = createUser("auth00");
+        long id=ruleAdminService.insert(new Rule(10, user.getName(), null, null, null,     "s1", "r1", "w1", "l1", GrantType.LIMIT));
+        RuleLimits limits = new RuleLimits();
+        limits.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits.setCatalogMode(CatalogMode.HIDE);
+        GeometryFactory facotry = new GeometryFactory();
+        MultiPolygon poly=facotry.createMultiPolygon();
+        limits.setAllowedArea(poly);
+        ruleAdminService.setLimits(id, limits);
+        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+        filter.setWorkspace("w1");
+        filter.setLayer("l1");
+
+        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
+        assertFalse(accessInfo.getAdminRights());
+        assertEquals(SpatialFilterType.CLIP, accessInfo.getSpatialFilterType());
     }
 
 }

--- a/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
+++ b/src/services/core/services-impl/src/test/java/org/geoserver/geofence/services/RuleReaderServiceImplTest.java
@@ -9,11 +9,11 @@ import org.geoserver.geofence.core.model.*;
 import org.locationtech.jts.geom.Geometry;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.geoserver.geofence.core.model.enums.*;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
-import org.geoserver.geofence.core.model.enums.AccessType;
-import org.geoserver.geofence.core.model.enums.GrantType;
 import org.geoserver.geofence.services.dto.AccessInfo;
 import org.geoserver.geofence.services.dto.RuleFilter;
 import org.geoserver.geofence.services.dto.RuleFilter.SpecialFilterType;
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import org.geoserver.geofence.core.model.enums.AdminGrantType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -856,25 +855,371 @@ public class RuleReaderServiceImplTest extends ServiceTestBase {
     }
 
 
-    public void testRuleWithSpatialFilterType() {
+    public void testRuleWithSpatialFilterType() throws ParseException {
 
         GSUser user = createUser("auth00");
         long id=ruleAdminService.insert(new Rule(10, user.getName(), null, null, null,     "s1", "r1", "w1", "l1", GrantType.LIMIT));
         RuleLimits limits = new RuleLimits();
         limits.setSpatialFilterType(SpatialFilterType.CLIP);
         limits.setCatalogMode(CatalogMode.HIDE);
-        GeometryFactory facotry = new GeometryFactory();
-        MultiPolygon poly=facotry.createMultiPolygon();
-        limits.setAllowedArea(poly);
+        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
+        MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
+        limits.setAllowedArea(area);
         ruleAdminService.setLimits(id, limits);
+
+
+        long id2=ruleAdminService.insert(new Rule(11, user.getName(), "group12", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
+        RuleLimits limits2 = new RuleLimits();
+        limits2.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits2.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
+        MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
+        limits2.setAllowedArea(area2);
+        ruleAdminService.setLimits(id2, limits2);
         RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
-        filter.setWorkspace("w1");
-        filter.setLayer("l1");
+        filter.setWorkspace("w11");
+        filter.setLayer("l11");
 
         AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
         assertEquals(GrantType.ALLOW, accessInfo.getGrant());
         assertFalse(accessInfo.getAdminRights());
-        assertEquals(SpatialFilterType.CLIP, accessInfo.getSpatialFilterType());
+
+        // area in same group, the result should an itersection of the
+        // two allowed area as a clip geometry.
+
+        Geometry testArea=area.intersection(area2);
+        testArea.normalize();
+        assertNull(accessInfo.getAreaWkt());
+        assertNotNull(accessInfo.getClipAreaWkt());
+
+        Geometry resultArea= (new WKTReader().read(accessInfo.getClipAreaWkt()));
+        resultArea.normalize();
+        assertTrue(testArea.equalsExact(resultArea,10.0E-15));
     }
+
+    public void testRuleSpatialFilterTypeClipSameGroup() throws ParseException {
+
+        // test that when we have two rules referring to the same group
+        // one having a filter type Intersects and the other one having filter type Clip
+        // the result is a clip area obtained by the intersection of the two.
+
+        UserGroup g1 = createRole("group11");
+        UserGroup g2 = createRole("group12");
+        GSUser user = createUser("auth11",g1,g2);
+
+        ruleAdminService.insert(new Rule(9999, null, null, null, null,     "s11", "r11", "w11", "l11", GrantType.ALLOW));
+        long id=ruleAdminService.insert(new Rule(10, user.getName(), "group11", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
+        RuleLimits limits = new RuleLimits();
+        limits.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
+        MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
+        limits.setAllowedArea(area);
+        ruleAdminService.setLimits(id, limits);
+
+
+        long id2=ruleAdminService.insert(new Rule(11, user.getName(), "group12", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
+        RuleLimits limits2 = new RuleLimits();
+        limits2.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits2.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
+        MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
+        limits2.setAllowedArea(area2);
+        ruleAdminService.setLimits(id2, limits2);
+        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+        filter.setWorkspace("w11");
+        filter.setLayer("l11");
+
+        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
+        assertFalse(accessInfo.getAdminRights());
+
+        // area in same group, the result should an itersection of the
+        // two allowed area as a clip geometry.
+
+        Geometry testArea=area.intersection(area2);
+        testArea.normalize();
+        assertNull(accessInfo.getAreaWkt());
+        assertNotNull(accessInfo.getClipAreaWkt());
+
+        Geometry resultArea= (new WKTReader().read(accessInfo.getClipAreaWkt()));
+        resultArea.normalize();
+        assertTrue(testArea.equalsExact(resultArea,10.0E-15));
+    }
+
+
+    @Test
+    public void testRuleSpatialFilterTypeIntersectsSameGroup() throws ParseException {
+
+        // test that when we have two rules referring to the same group
+        // both having a filter type Intersects
+        // the result is an intersect area obtained by the intersection of the two.
+
+        UserGroup g1 = createRole("group13");
+        UserGroup g2 = createRole("group14");
+        GSUser user = createUser("auth12",g1,g2);
+
+        ruleAdminService.insert(new Rule(9999, null, null, null, null,     "s11", "r11", "w11", "l11", GrantType.ALLOW));
+        long id=ruleAdminService.insert(new Rule(13, user.getName(), "group13", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
+        RuleLimits limits = new RuleLimits();
+        limits.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
+        MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
+        limits.setAllowedArea(area);
+        ruleAdminService.setLimits(id, limits);
+
+
+        long id2=ruleAdminService.insert(new Rule(14, user.getName(), "group14", null, null,     "s11", "r11", "w11", "l11", GrantType.LIMIT));
+        RuleLimits limits2 = new RuleLimits();
+        limits2.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits2.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
+        MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
+        limits2.setAllowedArea(area2);
+        ruleAdminService.setLimits(id2, limits2);
+        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+        filter.setWorkspace("w11");
+        filter.setLayer("l11");
+
+        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
+        assertFalse(accessInfo.getAdminRights());
+
+        // area in same group, the result should an itersection of the
+        // two allowed area as an intersects geometry.
+
+        Geometry testArea=area.intersection(area2);
+        testArea.normalize();
+        assertNull(accessInfo.getClipAreaWkt());
+        assertNotNull(accessInfo.getAreaWkt());
+
+        Geometry resultArea= (new WKTReader().read(accessInfo.getAreaWkt()));
+        resultArea.normalize();
+        assertTrue(testArea.equalsExact(resultArea,10.0E-15));
+    }
+
+
+    @Test
+    public void testRuleSpatialFilterTypeEnlargeAccess() throws ParseException {
+        // test the access enalargement behaviour with the SpatialFilterType.
+        // the user belongs to two groups. One with an allowedArea of type intersects,
+        // the other one with an allowed area of type clip. They should be returned
+        // separately in the final rule.
+
+        UserGroup g1 = createRole("group22");
+        UserGroup g2 = createRole("group23");
+        GSUser user = createUser("auth22", g1,g2);
+
+        ruleAdminService.insert(new Rule(999, null, null, null, null,     "s22", "r22", "w22", "l22", GrantType.ALLOW));
+
+        long id=ruleAdminService.insert(new Rule(15, null, "group22", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits = new RuleLimits();
+        limits.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
+        MultiPolygon area=(MultiPolygon)new WKTReader().read(areaWKT);
+        limits.setAllowedArea(area);
+        ruleAdminService.setLimits(id, limits);
+
+
+        long id2=ruleAdminService.insert(new Rule(16,null, "group23", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits2 = new RuleLimits();
+        limits2.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits2.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT2="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
+        MultiPolygon area2=(MultiPolygon)new WKTReader().read(areaWKT2);
+        limits2.setAllowedArea(area2);
+        ruleAdminService.setLimits(id2, limits2);
+        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+        filter.setWorkspace("w22");
+        filter.setLayer("l22");
+        filter.setUser(user.getName());
+        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
+        assertFalse(accessInfo.getAdminRights());
+
+        // we got a user in two groups one with an intersect spatialFilterType
+        // and the other with a clip spatialFilterType. The two area should haven
+        // been kept separated
+        assertNotNull(accessInfo.getAreaWkt());
+        assertNotNull(accessInfo.getClipAreaWkt());
+
+        // the intersects should be equal to the originally defined
+        // allowed area
+        Geometry intersects= new WKTReader().read(accessInfo.getAreaWkt());
+        intersects.normalize();
+        assertTrue(intersects.equalsExact(area, 10.0E-15));
+
+        // Since the two areas overlap the result clip geometry should
+        // be the difference between the define clip and the intersects
+        Geometry clip=new WKTReader().read(accessInfo.getClipAreaWkt()).difference(intersects);
+        clip.normalize();
+        Geometry areaDifference=area2.difference(area);
+        areaDifference.normalize();
+        assertTrue(clip.equalsExact(areaDifference,10.0E-15));
+    }
+
+
+    @Test
+    public void testRuleSpatialFilterTypeFourRules() throws ParseException {
+        // the user belongs to two groups and there are two rules for each group:
+        // INTERSECTS and CLIP for the first, and CLIP CLIP for the second.
+        // The expected result is only one allowedArea of type clip
+        // obtained by the intersection of the firs two, united with the intersection of the second two.
+        // the first INTERSECTS is resolve as CLIP because during constraint resolution the more restrictive
+        // type is chosen.
+
+        UserGroup g1 = createRole("group31");
+        UserGroup g2 = createRole("group32");
+        GSUser user = createUser("auth33", g1,g2);
+
+        WKTReader reader = new WKTReader();
+
+        ruleAdminService.insert(new Rule(999, null, null, null, null,     "s22", "r22", "w22", "l22", GrantType.ALLOW));
+
+        long id=ruleAdminService.insert(new Rule(17, null, "group31", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits = new RuleLimits();
+        limits.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
+        MultiPolygon area=(MultiPolygon)reader.read(areaWKT);
+        limits.setAllowedArea(area);
+        ruleAdminService.setLimits(id, limits);
+
+        long id2=ruleAdminService.insert(new Rule(18,null, "group31", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits2 = new RuleLimits();
+        limits2.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits2.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT2="MultiPolygon (((-1.46109090909091011 5.68500000000000139, -0.68600000000000083 5.7651818181818193, -0.73945454545454625 2.00554545454545519, -1.54127272727272846 1.9610000000000003, -1.46109090909091011 5.68500000000000139)))";
+        MultiPolygon area2=(MultiPolygon)reader.read(areaWKT2);
+        limits2.setAllowedArea(area2);
+        ruleAdminService.setLimits(id2, limits2);
+
+        long id3=ruleAdminService.insert(new Rule(19,null, "group32", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits3 = new RuleLimits();
+        limits3.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits3.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT3="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
+        MultiPolygon area3=(MultiPolygon)reader.read(areaWKT3);
+        limits3.setAllowedArea(area3);
+        ruleAdminService.setLimits(id3, limits3);
+
+
+        long id4=ruleAdminService.insert(new Rule(20,null, "group32", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits4 = new RuleLimits();
+        limits4.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits4.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT4="MultiPolygon (((-1.30963636363636482 5.96118181818181991, 1.78181818181818175 4.84754545454545571, -0.90872727272727349 2.26390909090909132, -1.30963636363636482 5.96118181818181991)))";
+        MultiPolygon area4=(MultiPolygon)reader.read(areaWKT4);
+        limits4.setAllowedArea(area4);
+        ruleAdminService.setLimits(id4, limits4);
+
+
+        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+        filter.setWorkspace("w22");
+        filter.setLayer("l22");
+        filter.setUser(user.getName());
+        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
+        assertFalse(accessInfo.getAdminRights());
+        // we should have only the clip geometry
+        assertNull(accessInfo.getAreaWkt());
+        assertNotNull(accessInfo.getClipAreaWkt());
+
+        // the intersects should be equal to the originally defined
+        // allowed area
+
+        Geometry expectedResult=area.intersection(area2).union(area3.intersection(area4));
+        expectedResult.normalize();
+        Geometry clip=reader.read(accessInfo.getClipAreaWkt());
+        clip.normalize();
+        assertTrue(clip.equalsExact(expectedResult,10.0E-15));
+    }
+
+
+    @Test
+    public void testRuleSpatialFilterTypeFourRules2() throws ParseException {
+        // the user belongs to two groups and there are two rules for each group:
+        // CLIP and CLIP for the first, and INTERSECTS INTERSECTS for the second.
+        // The expected result are two allowedArea the first of type clip and second of type intersects.
+
+        UserGroup g1 = createRole("group41");
+        UserGroup g2 = createRole("group42");
+        GSUser user = createUser("auth44", g1,g2);
+
+        WKTReader reader = new WKTReader();
+
+        ruleAdminService.insert(new Rule(999, null, null, null, null,     "s22", "r22", "w22", "l22", GrantType.ALLOW));
+
+        long id=ruleAdminService.insert(new Rule(21, null, "group41", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits = new RuleLimits();
+        limits.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT= "MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
+        MultiPolygon area=(MultiPolygon)reader.read(areaWKT);
+        limits.setAllowedArea(area);
+        ruleAdminService.setLimits(id, limits);
+
+        long id2=ruleAdminService.insert(new Rule(22,null, "group41", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits2 = new RuleLimits();
+        limits2.setSpatialFilterType(SpatialFilterType.CLIP);
+        limits2.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT2="MultiPolygon (((-1.46109090909091011 5.68500000000000139, -0.68600000000000083 5.7651818181818193, -0.73945454545454625 2.00554545454545519, -1.54127272727272846 1.9610000000000003, -1.46109090909091011 5.68500000000000139)))";
+        MultiPolygon area2=(MultiPolygon)reader.read(areaWKT2);
+        limits2.setAllowedArea(area2);
+        ruleAdminService.setLimits(id2, limits2);
+
+        long id3=ruleAdminService.insert(new Rule(23,null, "group42", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits3 = new RuleLimits();
+        limits3.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits3.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT3="MultiPolygon (((-1.78181818181818308 5.95227272727272894, -0.16927272727272813 5.4711818181818197, 1.97781818181818148 3.81409090909090986, 1.93327272727272748 2.05009090909090919, -2.6638181818181832 2.64700000000000069, -1.78181818181818308 5.95227272727272894)))";
+        MultiPolygon area3=(MultiPolygon)reader.read(areaWKT3);
+        limits3.setAllowedArea(area3);
+        ruleAdminService.setLimits(id3, limits3);
+
+
+        long id4=ruleAdminService.insert(new Rule(24,null, "group42", null, null,     "s22", "r22", "w22", "l22", GrantType.LIMIT));
+        RuleLimits limits4 = new RuleLimits();
+        limits4.setSpatialFilterType(SpatialFilterType.INTERSECTS);
+        limits4.setCatalogMode(CatalogMode.HIDE);
+        String areaWKT4="MultiPolygon (((-1.30963636363636482 5.96118181818181991, 1.78181818181818175 4.84754545454545571, -0.90872727272727349 2.26390909090909132, -1.30963636363636482 5.96118181818181991)))";
+        MultiPolygon area4=(MultiPolygon)reader.read(areaWKT4);
+        limits4.setAllowedArea(area4);
+        ruleAdminService.setLimits(id4, limits4);
+
+
+        RuleFilter filter = new RuleFilter(SpecialFilterType.ANY, true);
+        filter.setWorkspace("w22");
+        filter.setLayer("l22");
+        filter.setUser(user.getName());
+        AccessInfo accessInfo = ruleReaderService.getAccessInfo(filter);
+        assertEquals(GrantType.ALLOW, accessInfo.getGrant());
+        assertFalse(accessInfo.getAdminRights());
+
+        // we should have both
+        assertNotNull(accessInfo.getAreaWkt());
+        assertNotNull(accessInfo.getClipAreaWkt());
+
+        // the intersects should be equal to the originally defined
+        // allowed area
+
+        Geometry expectedIntersects=area3.intersection(area4);
+        expectedIntersects.normalize();
+        Geometry intersects=reader.read(accessInfo.getAreaWkt());
+        intersects.normalize();
+        System.out.println(intersects.toString());
+        System.out.println(expectedIntersects.toString());
+        assertTrue(expectedIntersects.equalsExact(intersects,10.0E-15));
+
+        Geometry clip=reader.read(accessInfo.getClipAreaWkt()).difference(intersects);
+        clip.normalize();
+        Geometry expectedClip=area2.intersection(area).difference(intersects);
+        expectedClip.normalize();
+        assertTrue(expectedClip.equalsExact(clip,10.0E-15));
+
+    }
+
 
 }

--- a/src/services/modules/rest/api/src/main/java/org/geoserver/geofence/services/rest/model/RESTLayerConstraints.java
+++ b/src/services/modules/rest/api/src/main/java/org/geoserver/geofence/services/rest/model/RESTLayerConstraints.java
@@ -7,6 +7,7 @@ package org.geoserver.geofence.services.rest.model;
 
 import org.geoserver.geofence.core.model.LayerAttribute;
 import org.geoserver.geofence.core.model.enums.LayerType;
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 
 import java.util.Set;
 
@@ -21,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "LayerConstraints")
 @XmlType(propOrder = {"type", "defaultStyle", "cqlFilterRead", "cqlFilterWrite", "restrictedAreaWkt",
-    "allowedStyles", "attributes"})
+   "spatialFilterType", "allowedStyles", "attributes"})
 public class RESTLayerConstraints {
 
     private LayerType type;
@@ -29,6 +30,7 @@ public class RESTLayerConstraints {
     private String cqlFilterRead;
     private String cqlFilterWrite;
     private String restrictedAreaWkt;
+    private SpatialFilterType spatialFilterType;
     private Set<String> allowedStyles;
     private Set<LayerAttribute> attributes;
 
@@ -92,6 +94,14 @@ public class RESTLayerConstraints {
         this.type = type;
     }
 
+    public SpatialFilterType getSpatialFilterType() {
+        return spatialFilterType;
+    }
+
+    public void setSpatialFilterType(SpatialFilterType spatialFilterType) {
+        this.spatialFilterType = spatialFilterType;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append('[');
@@ -105,6 +115,8 @@ public class RESTLayerConstraints {
             sb.append(" cqlW:").append(cqlFilterWrite);
         if(restrictedAreaWkt != null)
             sb.append(" wkt:").append(restrictedAreaWkt);
+        if (spatialFilterType!=null)
+            sb.append(" spatialFilterType").append(spatialFilterType);
         if(allowedStyles != null)
             sb.append(" styles(").append(allowedStyles.size()).append("):").append(allowedStyles);
         if(attributes != null)

--- a/src/services/modules/rest/impl/src/main/java/org/geoserver/geofence/services/rest/impl/RESTAdminRuleServiceImpl.java
+++ b/src/services/modules/rest/impl/src/main/java/org/geoserver/geofence/services/rest/impl/RESTAdminRuleServiceImpl.java
@@ -327,6 +327,7 @@ public class RESTAdminRuleServiceImpl
         }
 
         rule.setWorkspace(in.getWorkspace());
+        rule.setWorkspace(in.getWorkspace());
 
         return rule;
     }

--- a/src/services/modules/rest/impl/src/main/java/org/geoserver/geofence/services/rest/impl/RESTAdminRuleServiceImpl.java
+++ b/src/services/modules/rest/impl/src/main/java/org/geoserver/geofence/services/rest/impl/RESTAdminRuleServiceImpl.java
@@ -327,7 +327,6 @@ public class RESTAdminRuleServiceImpl
         }
 
         rule.setWorkspace(in.getWorkspace());
-        rule.setWorkspace(in.getWorkspace());
 
         return rule;
     }

--- a/src/services/modules/rest/impl/src/main/java/org/geoserver/geofence/services/rest/impl/RESTRuleServiceImpl.java
+++ b/src/services/modules/rest/impl/src/main/java/org/geoserver/geofence/services/rest/impl/RESTRuleServiceImpl.java
@@ -570,6 +570,9 @@ public class RESTRuleServiceImpl
                 String areaWKT="SRID="+area.getSRID()+";"+area.toText();
                 constraints.setRestrictedAreaWkt(areaWKT);
             }
+            if (details.getSpatialFilterType()!=null){
+                constraints.setSpatialFilterType(details.getSpatialFilterType());
+            }
 
             constraints.setType(details.getType());
 
@@ -628,6 +631,8 @@ public class RESTRuleServiceImpl
                 }
                 details.setArea((MultiPolygon) g);
             }
+
+            details.setSpatialFilterType(constraints.getSpatialFilterType());
 
             details.setType(constraints.getType());
 


### PR DESCRIPTION
Add the possibility to configure the allowedArea filter as a Intersecting filter or as a Clip filter:

- new Enum SpatialFilterType;
- new fieldSpatialFilterType in model objects;
- necessary logic to display a comboBox with the two values (INTERSECTS, CLIP) in the ruleLimits editor and in the layerDetails editor;
- updated rest;
- updated create-schema sql files, and added update-schema sql to add the new column to the db.
- consistent management for rule resolution and rule enalrgement:
  1. when going stricter the Clip spatial filter type is priviledged;
  2. when enlarging access Clip and intersects are treated separetely and returing in the dto as separated geometry.
  3. if intersects area and clip area in the final AccessInfo are overlapping from the clip area will be subtracted the overlapping part.