### PR TITLE
Remove duplicate groupId and version from non-root poms

### DIFF
--- a/src/services/core/model-external/pom.xml
+++ b/src/services/core/model-external/pom.xml
@@ -16,8 +16,7 @@
         <artifactId>geofence-core</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-  
-    <groupId>org.geoserver.geofence</groupId>
+
     <artifactId>geofence-model</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Core - Model external</name>

--- a/src/services/core/model/pom.xml
+++ b/src/services/core/model/pom.xml
@@ -16,8 +16,7 @@
         <artifactId>geofence-core</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-  
-    <groupId>org.geoserver.geofence</groupId>
+
     <artifactId>geofence-model-internal</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Core - Model internal</name>

--- a/src/services/core/persistence/pom.xml
+++ b/src/services/core/persistence/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-persistence</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Core - Persistence</name>

--- a/src/services/core/pom.xml
+++ b/src/services/core/pom.xml
@@ -16,8 +16,7 @@
         <artifactId>geofence-root</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-  
-    <groupId>org.geoserver.geofence</groupId>
+
     <artifactId>geofence-core</artifactId>
     <name>GeoFence - Core</name>
     <packaging>pom</packaging>

--- a/src/services/core/services-api/pom.xml
+++ b/src/services/core/services-api/pom.xml
@@ -17,7 +17,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-services-api</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Core - Services API</name>

--- a/src/services/core/services-impl/pom.xml
+++ b/src/services/core/services-impl/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-services-impl</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Core - Services implementation</name>

--- a/src/services/core/webtest/pom.xml
+++ b/src/services/core/webtest/pom.xml
@@ -14,7 +14,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
 	<artifactId>geofence-webtest</artifactId>
 	<packaging>war</packaging>
 

--- a/src/services/modules/generic-api/pom.xml
+++ b/src/services/modules/generic-api/pom.xml
@@ -17,7 +17,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-generic-api</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Module - Generic API</name>

--- a/src/services/modules/ldap/pom.xml
+++ b/src/services/modules/ldap/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-ldap</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Module - LDAP Support</name>

--- a/src/services/modules/login/api/pom.xml
+++ b/src/services/modules/login/api/pom.xml
@@ -17,7 +17,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-login-api</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Modules - Login - API</name>

--- a/src/services/modules/login/impl/pom.xml
+++ b/src/services/modules/login/impl/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-login-impl</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Modules - Login - Impl</name>

--- a/src/services/modules/login/pom.xml
+++ b/src/services/modules/login/pom.xml
@@ -17,7 +17,6 @@
 	  <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-login-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>GeoFence - Modules - Login</name>

--- a/src/services/modules/pom.xml
+++ b/src/services/modules/pom.xml
@@ -16,8 +16,6 @@
         <artifactId>geofence-root</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-modules</artifactId>
     <packaging>pom</packaging>
     <name>GeoFence - Modules - 0 Root</name>

--- a/src/services/modules/rest/api/pom.xml
+++ b/src/services/modules/rest/api/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-rest-api</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Modules - REST API</name>

--- a/src/services/modules/rest/client/pom.xml
+++ b/src/services/modules/rest/client/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-rest-client</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Modules - REST client</name>

--- a/src/services/modules/rest/impl/pom.xml
+++ b/src/services/modules/rest/impl/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-rest-impl</artifactId>
     <packaging>jar</packaging>
     <name>GeoFence - Modules - REST services implementation</name>

--- a/src/services/modules/rest/pom.xml
+++ b/src/services/modules/rest/pom.xml
@@ -16,8 +16,6 @@
         <artifactId>geofence-modules</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-rest-root</artifactId>
     <name>GeoFence - Modules - REST root</name>
     <packaging>pom</packaging>

--- a/src/services/modules/rest/test/pom.xml
+++ b/src/services/modules/rest/test/pom.xml
@@ -15,7 +15,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-rest-test</artifactId>
 	<packaging>war</packaging>
 

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -13,10 +13,7 @@
         <artifactId>geofence</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-root</artifactId>
-    <version>3.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GeoFence - 0 Services </name>

--- a/src/web/pom.xml
+++ b/src/web/pom.xml
@@ -13,10 +13,8 @@
         <artifactId>geofence</artifactId>
         <version>3.5-SNAPSHOT</version>
     </parent>
-    
-    <groupId>org.geoserver.geofence</groupId>
+
     <artifactId>geofence-web</artifactId>
-    <version>3.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GeoFence - Web</name>    

--- a/src/web/webapp/pom.xml
+++ b/src/web/webapp/pom.xml
@@ -14,7 +14,6 @@
         <version>3.5-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.geoserver.geofence</groupId>
     <artifactId>geofence-webapp</artifactId>
     <packaging>war</packaging>
 


### PR DESCRIPTION
Good first pr :)

`groupId` and `version` in non-root `pom.xml` files are inherited and reported as a warning in eclipse.