### PR TITLE
Switch to the same log4j version  used by GT2/GWC/GS

### DIFF
--- a/src/gui/pom.xml
+++ b/src/gui/pom.xml
@@ -567,7 +567,6 @@
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
             </dependency>
 
             <!-- =========================================================== -->

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -129,7 +129,7 @@
           <url>scp://demo.geo-solutions.it/var/www/share/github/gsman</url>
         </site>
    </distributionManagement -->
-   
+
    <profiles>
       <profile>
          <id>jdk11+</id>

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -254,7 +254,7 @@
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <version>1.2.17.norce</version>
             </dependency>
 
 <!--            <dependency>

--- a/src/web/pom.xml
+++ b/src/web/pom.xml
@@ -482,7 +482,7 @@
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <version>1.2.17.norce</version>
             </dependency>
 
             <!-- =========================================================== -->


### PR DESCRIPTION
@etj this is an update of the log4j dependency. I've verified the right jar ends up in the webapp war file.