### PR TITLE
[GEOS-10507] GeoFence - Inserting multiple GeoFence rules together

### DIFF
--- a/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/impl/AdminRuleDAOImpl.java
+++ b/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/impl/AdminRuleDAOImpl.java
@@ -20,6 +20,7 @@ import org.geoserver.geofence.core.model.AdminRule;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -33,6 +34,7 @@ public class AdminRuleDAOImpl extends PrioritizableDAOImpl<AdminRule> implements
     private static final Logger LOGGER = LogManager.getLogger(AdminRuleDAOImpl.class);
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRED, value = "geofenceTransactionManager")
     public void persist(AdminRule... entities) {
 
         // TODO: check if there are any dups in the input list
@@ -66,6 +68,7 @@ public class AdminRuleDAOImpl extends PrioritizableDAOImpl<AdminRule> implements
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRED, value = "geofenceTransactionManager")
     public long persist(AdminRule entity, InsertPosition position) {
 
         return super.persist(AdminRule.class, entity, position);

--- a/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/impl/RuleDAOImpl.java
+++ b/src/services/core/persistence/src/main/java/org/geoserver/geofence/core/dao/impl/RuleDAOImpl.java
@@ -21,6 +21,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.geoserver.geofence.core.dao.DuplicateKeyException;
 
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -34,6 +35,7 @@ public class RuleDAOImpl extends PrioritizableDAOImpl<Rule> implements RuleDAO {
     private static final Logger LOGGER = LogManager.getLogger(RuleDAOImpl.class);
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRED, value = "geofenceTransactionManager")
     public void persist(Rule... entities) throws DuplicateKeyException {
 
         // TODO: check if there are any dups in the input list
@@ -70,6 +72,7 @@ public class RuleDAOImpl extends PrioritizableDAOImpl<Rule> implements RuleDAO {
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRED, value = "geofenceTransactionManager")
     public long persist(Rule entity, InsertPosition position) {
 
         return super.persist(Rule.class, entity, position);

--- a/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/AdminRuleAdminService.java
+++ b/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/AdminRuleAdminService.java
@@ -28,6 +28,17 @@ public interface AdminRuleAdminService
 
     long insert(AdminRule rule);
 
+    /**
+     * Inserts a list of admin rules
+     *
+     * @param list of admin rules to be inserted
+     */
+    default void insert(List<AdminRule> rules) {
+        for (AdminRule rule: rules) {
+            insert(rule);
+        }
+    }
+
     long insert(AdminRule rule, InsertPosition position);
 
     long update(AdminRule rule) throws NotFoundServiceEx;
@@ -128,7 +139,7 @@ public interface AdminRuleAdminService
      * @throws BadRequestServiceEx if a wildcard type is used in filter
      */
     ShortAdminRule getRule(RuleFilter filter) throws BadRequestServiceEx;
-    
+
     /**
      * Return the Rules according to the filter.
      * Rules will be enriched with all their joined data, so this method may be heavy to execute.

--- a/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/RuleAdminService.java
+++ b/src/services/core/services-api/src/main/java/org/geoserver/geofence/services/RuleAdminService.java
@@ -5,6 +5,8 @@
 
 package org.geoserver.geofence.services;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.geoserver.geofence.core.model.LayerDetails;
 import org.geoserver.geofence.core.model.Rule;
 import org.geoserver.geofence.core.model.RuleLimits;
@@ -32,6 +34,19 @@ public interface RuleAdminService
     long insert(Rule rule);
 
     long insert(Rule rule, InsertPosition position);
+
+    /**
+     * @param rules to be inserted
+     * @return map of inserted rules along with their ids.
+     */
+    default Map<Long, Rule> insert(Set<Rule> rules) {
+        Map<Long, Rule> output = new HashMap<>();
+        for (Rule rule: rules) {
+            long id = insert(rule);
+            output.put(id, rule);
+        }
+        return output;
+    }
 
     long update(Rule rule) throws NotFoundServiceEx;
 
@@ -134,7 +149,7 @@ public interface RuleAdminService
      * @throws BadRequestServiceEx if a wildcard type is used in filter
      */
     ShortRule getRule(RuleFilter filter) throws BadRequestServiceEx;
-    
+
     /**
      * Return the Rules according to the filter.
      * Rules will be enriched with all their joined data, so this method may be heavy to execute.

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/AdminRuleAdminServiceImpl.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/AdminRuleAdminServiceImpl.java
@@ -47,6 +47,16 @@ public class AdminRuleAdminServiceImpl implements AdminRuleAdminService {
         return rule.getId();
     }
 
+    /**
+     * Inserts a list of admin rules
+     *
+     * @param list of admin rules to be inserted
+     */
+    @Override
+    public void insert(List<AdminRule> rules) {
+        ruleDAO.persist(rules.toArray(new AdminRule[rules.size()]));
+    }
+
     @Override
     public long insert(AdminRule rule, InsertPosition position) {
         ruleDAO.persist(rule, position);

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/RuleAdminServiceImpl.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/RuleAdminServiceImpl.java
@@ -7,6 +7,8 @@ package org.geoserver.geofence.services;
 
 import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.Search;
+import java.util.HashMap;
+import java.util.Map;
 import org.geoserver.geofence.core.dao.LayerDetailsDAO;
 import org.geoserver.geofence.core.dao.RuleDAO;
 import org.geoserver.geofence.core.dao.RuleLimitsDAO;
@@ -62,6 +64,22 @@ public class RuleAdminServiceImpl implements RuleAdminService {
         sanitizeFields(rule);
         ruleDAO.persist(rule);
         return rule.getId();
+    }
+
+    /**
+     * @param rules to be inserted
+     * @return map of inserted rules along with their ids.
+     */
+    @Override
+    public Map<Long, Rule> insert(Set<Rule> rules) {
+        rules.forEach(this::sanitizeFields);
+        LOGGER.info("Inserting a set of rules.");
+        ruleDAO.persist(rules.toArray(new Rule[0]));
+        Map<Long, Rule> rulesMap = new HashMap<>();
+        for (Rule rule: rules) {
+            rulesMap.put(rule.getId(), rule);
+        }
+        return rulesMap;
     }
 
     @Override

--- a/src/services/modules/rest/api/src/main/java/org/geoserver/geofence/services/rest/RESTAdminRuleService.java
+++ b/src/services/modules/rest/api/src/main/java/org/geoserver/geofence/services/rest/RESTAdminRuleService.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.geofence.services.rest;
 
+import java.util.List;
 import org.geoserver.geofence.services.rest.exception.BadRequestRestEx;
 import org.geoserver.geofence.services.rest.exception.InternalErrorRestEx;
 import org.geoserver.geofence.services.rest.exception.NotFoundRestEx;
@@ -39,6 +40,11 @@ public interface RESTAdminRuleService
     @Path("/")
     @Produces(MediaType.APPLICATION_XML)
     Response insert(@Multipart("rule") RESTInputAdminRule rule) throws BadRequestRestEx, NotFoundRestEx;
+
+    @POST
+    @Path("/all")
+    @Produces(MediaType.APPLICATION_XML)
+    Response insertAll(@Multipart("rule") List<RESTInputAdminRule> rules) throws BadRequestRestEx, NotFoundRestEx;
 
     @GET
     @Path("/id/{id}")

--- a/src/services/modules/rest/api/src/main/java/org/geoserver/geofence/services/rest/RESTRuleService.java
+++ b/src/services/modules/rest/api/src/main/java/org/geoserver/geofence/services/rest/RESTRuleService.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.geofence.services.rest;
 
+import java.util.List;
 import org.geoserver.geofence.services.rest.exception.BadRequestRestEx;
 import org.geoserver.geofence.services.rest.exception.InternalErrorRestEx;
 import org.geoserver.geofence.services.rest.exception.NotFoundRestEx;
@@ -39,6 +40,11 @@ public interface RESTRuleService
     @Path("/")
     @Produces(MediaType.TEXT_PLAIN)
     Response insert(@Multipart("rule") RESTInputRule rule) throws BadRequestRestEx, NotFoundRestEx;
+
+    @POST
+    @Path("/all")
+    @Produces(MediaType.TEXT_PLAIN)
+    Response insertAll(@Multipart("rule") List<RESTInputRule> rules) throws BadRequestRestEx, NotFoundRestEx;
 
     @GET
     @Path("/id/{id}")

--- a/src/services/modules/rest/impl/src/test/java/org/geoserver/geofence/services/rest/impl/RESTRuleServiceImplTest.java
+++ b/src/services/modules/rest/impl/src/test/java/org/geoserver/geofence/services/rest/impl/RESTRuleServiceImplTest.java
@@ -5,6 +5,8 @@
 
 package org.geoserver.geofence.services.rest.impl;
 
+import java.util.List;
+import java.util.Map;
 import org.geoserver.geofence.core.model.Rule;
 import org.geoserver.geofence.services.RuleAdminService;
 import org.geoserver.geofence.services.rest.model.RESTInputUser;
@@ -73,6 +75,43 @@ public class RESTRuleServiceImplTest extends RESTBaseTest {
             assertNotNull(out);
             assertEquals("user0", out.getUsername());
             assertNull(out.getConstraints());
+        }
+    }
+
+    @Test
+    public void testInsertAll() {
+        RESTInputGroup group = new RESTInputGroup();
+        group.setName("g1");
+        restUserGroupService.insert(group);
+
+        RESTInputUser user = new RESTInputUser();
+        user.setName("user0");
+        user.setEnabled(Boolean.TRUE);
+        user.setGroups(new ArrayList<IdName>());
+        user.getGroups().add(new IdName("g1"));
+        restUserService.insert(user);
+
+        RESTInputRule rule0 = new RESTInputRule();
+        rule0.setUsername("user0");
+        rule0.setPosition(new RESTRulePosition(RESTRulePosition.RulePosition.offsetFromTop, 0));
+        rule0.setGrant(GrantType.ALLOW);
+        RESTInputRule rule1 = new RESTInputRule();
+        rule1.setUsername("user1");
+        rule1.setPosition(new RESTRulePosition(RESTRulePosition.RulePosition.offsetFromTop, 0));
+        rule1.setGrant(GrantType.ALLOW);
+        List<RESTInputRule> rules = new ArrayList<RESTInputRule>();
+        rules.add(rule0);
+        rules.add(rule1);
+
+        Map<Long, Rule> ids = (Map<Long, Rule>) restRuleService.insertAll(rules).getEntity();
+        assertNotNull(ids);
+
+        {
+            for(Long id: ids.keySet()){
+                RESTOutputRule out = restRuleService.get(id);
+                assertNotNull(out);
+                assertNull(out.getConstraints());
+            }
         }
     }
 


### PR DESCRIPTION
We would like to allows users to insert a set of GeoFence rules in one API call. Internally, the API will either succeed in inserting all the rules, or fail in inserting all of them. (We are not allowing insertion for only a subset of the passed rules to the API call).