### PR TITLE
Making the code build with Java 11

### DIFF
--- a/src/gui/core/plugin/mapsui/pom.xml
+++ b/src/gui/core/plugin/mapsui/pom.xml
@@ -211,10 +211,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
-				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
-				</configuration>
 			</plugin>
 			
 			<plugin>

--- a/src/gui/core/plugin/userui/pom.xml
+++ b/src/gui/core/plugin/userui/pom.xml
@@ -192,10 +192,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/src/gui/core/pom.xml
+++ b/src/gui/core/pom.xml
@@ -30,15 +30,7 @@
         <pluginManagement>
             <plugins>
 
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <encoding>utf8</encoding>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
+
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/gui/core/resources/pom.xml
+++ b/src/gui/core/resources/pom.xml
@@ -199,17 +199,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-			<!-- tell the compiler we can use 1.5 -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 			</plugin>

--- a/src/gui/pom.xml
+++ b/src/gui/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <module.name>geofence-gui</module.name>
         <geofence-version>3.6-SNAPSHOT</geofence-version>
-        <gt-version>21.4</gt-version>
+        <gt-version>29.2</gt-version>
         <geogwt-version>0.4-SNAPSHOT</geogwt-version>
 
         <spring.version>4.2.5.RELEASE</spring.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -14,6 +14,11 @@
    <packaging>pom</packaging>
 
    <properties>
+     <!-- Building with Java 11, but with Java 8 compatible jars,
+          to have some mercy on the old java bytecode processing libraries
+          used in GeoFence -->
+     <maven.compiler.source>8</maven.compiler.source>
+     <maven.compiler.target>8</maven.compiler.target>
      <geofence-version>3.6-SNAPSHOT</geofence-version>
      <hibernate-version>3.6.9.Final</hibernate-version>
      <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>
@@ -127,7 +132,7 @@
       
    <modules>
       <module>services</module>
-      <module>gui</module>
+      <!--module>gui</module-->
    </modules>
    
    <build>

--- a/src/services/core/model-external/pom.xml
+++ b/src/services/core/model-external/pom.xml
@@ -31,6 +31,15 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/src/services/core/model/pom.xml
+++ b/src/services/core/model/pom.xml
@@ -43,8 +43,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>

--- a/src/services/core/webtest/pom.xml
+++ b/src/services/core/webtest/pom.xml
@@ -113,10 +113,6 @@
         <!-- =============================================================== -->
 		<!-- CXF -->
         <!-- =============================================================== -->
-        <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-        </dependency>
 <!--        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-http</artifactId>
@@ -242,15 +238,6 @@
            <finalName>geofence-web-test</finalName>
            
            <plugins>
-              <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-compiler-plugin</artifactId>
-                 <configuration>
-                    <encoding>utf8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                 </configuration>
-              </plugin>
 
               <plugin>
                  <groupId>org.apache.maven.plugins</groupId>

--- a/src/services/modules/generic-api/pom.xml
+++ b/src/services/modules/generic-api/pom.xml
@@ -47,19 +47,14 @@
             <version>1.0-alpha-4</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-
             <!-- Attach sources ============================================ -->
             <plugin>
                 <inherited>true</inherited>

--- a/src/services/modules/ldap/pom.xml
+++ b/src/services/modules/ldap/pom.xml
@@ -115,6 +115,16 @@
             <version>1.5.5</version>
             <scope>test</scope>
         </dependency>
+        <!-- This is needed for the server to start, yes, with a different
+             version compared to the other bits, horrible but working, see
+             https://github.com/spring-projects/spring-security/issues/6804#issuecomment-572568328
+        -->
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-core-avl</artifactId>
+            <version>1.5.7</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.directory.shared</groupId>
             <artifactId>shared-ldap</artifactId>
@@ -143,15 +153,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-
             <!-- Attach sources ============================================ -->
             <plugin>
                 <inherited>true</inherited>

--- a/src/services/modules/login/api/pom.xml
+++ b/src/services/modules/login/api/pom.xml
@@ -51,18 +51,15 @@
             <version>1.0-alpha-4</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
 
             <!-- Attach sources ============================================ -->
             <plugin>

--- a/src/services/modules/login/impl/pom.xml
+++ b/src/services/modules/login/impl/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>cxf-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
+        </dependency>
+
 
         <!-- =============================================================== -->
         <!-- JUnit -->
@@ -89,17 +95,6 @@
                 </includes>
             </resource>
         </resources>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
   
 </project>

--- a/src/services/modules/rest/api/pom.xml
+++ b/src/services/modules/rest/api/pom.xml
@@ -71,15 +71,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-
             <!-- Attach sources ============================================ -->
 <!--
             <plugin>

--- a/src/services/modules/rest/client/pom.xml
+++ b/src/services/modules/rest/client/pom.xml
@@ -70,15 +70,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-
             <!-- Attach sources ============================================ -->
 
             <plugin>

--- a/src/services/modules/rest/impl/pom.xml
+++ b/src/services/modules/rest/impl/pom.xml
@@ -49,6 +49,11 @@
         <!-- ================================================================-->
 
         <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <version>3.1.5</version>
@@ -149,14 +154,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
 
             <!-- Attach sources ============================================ -->
 <!--

--- a/src/services/modules/rest/test/pom.xml
+++ b/src/services/modules/rest/test/pom.xml
@@ -120,10 +120,6 @@
         <!-- =============================================================== -->
 		<!-- CXF -->
         <!-- =============================================================== -->
-        <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-        </dependency>
 <!--        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-http</artifactId>
@@ -274,15 +270,6 @@
 	<build>
 
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<encoding>utf8</encoding>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <main-prefix>geofence</main-prefix>
 
-        <gt-version>28-SNAPSHOT</gt-version>
+        <gt-version>29.2</gt-version>
 
         <cxf-version>3.1.5</cxf-version>
         <activemq-version>5.3.0.4-fuse</activemq-version>
@@ -74,6 +74,7 @@
         <javassist-version>3.8.0.GA</javassist-version>
 
         <gsmanager-version>1.3.3-SNAPSHOT</gsmanager-version>
+
     </properties>
 
     <!-- =========================================================== -->
@@ -319,17 +320,6 @@
 		    <!-- =========================================================== -->
 		    <!--     APACHE CXF                                              -->
 		    <!-- =========================================================== -->
-            <dependency>
-                <groupId>javax.xml.ws</groupId>
-                <artifactId>jaxws-api</artifactId>
-                <version>${jaxws-version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.jws</groupId>
-                        <artifactId>jsr181-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
             <dependency>
                 <groupId>org.apache.cxf</groupId>
@@ -413,14 +403,19 @@
             <!--     JAXB                                                    -->
             <!-- =========================================================== -->
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>2.2.12</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>2.2.11</version>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.3</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
+                <version>2.3.3</version>
             </dependency>
 
             <!-- =========================================================== -->
@@ -665,6 +660,12 @@
                 <version>${hibernate-spatial-version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.23.1-GA</version>
+            </dependency>
+
 		    <!-- =========================================================== -->
 		    <!--     POSTGRES- POSTGIS                                       -->
 		    <!-- =========================================================== -->
@@ -804,24 +805,7 @@
     <build>
         <plugins>
             <!-- compilation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <debug>true</debug>
-                    <encoding>UTF-8</encoding>
-					       <!--
-					           On the win32 build box the compiler oom's due to the compiler accumulating
-					           too many classes in the permanent generation, similar to GEOT-2462
-					       -->
-                    <fork>true</fork>
-                    <meminitial>128M</meminitial>
-                    <maxmem>1512M</maxmem>
-                </configuration>
-            </plugin>
+
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR makes the code build with Java 11. As a side effect of the dependencies upgrades, it will also only build with Java 11 or bigger, as some bits of them are Java 11 only by now.