### PR TITLE
[GEOT-7287] GeoTools API Change refactoring org.opengis to org.geotools.api

### DIFF
--- a/src/gui/core/plugin/mapsui/src/main/java/org/geoserver/geofence/gui/server/utility/GeometryUtility.java
+++ b/src/gui/core/plugin/mapsui/src/main/java/org/geoserver/geofence/gui/server/utility/GeometryUtility.java
@@ -18,11 +18,11 @@ import org.geoserver.geofence.core.model.adapter.PolygonAdapter;
 
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
-import org.opengis.geometry.MismatchedDimensionException;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.NoSuchAuthorityCodeException;
-import org.opengis.referencing.operation.MathTransform;
-import org.opengis.referencing.operation.TransformException;
+import org.geotools.api.geometry.MismatchedDimensionException;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
 import org.springframework.stereotype.Component;
 
 

--- a/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/RuleReaderServiceImpl.java
+++ b/src/services/core/services-impl/src/main/java/org/geoserver/geofence/services/RuleReaderServiceImpl.java
@@ -28,10 +28,10 @@ import org.geoserver.geofence.services.dto.ShortRule;
 import org.geoserver.geofence.services.exception.BadRequestServiceEx;
 import org.geoserver.geofence.services.util.AccessInfoInternal;
 import org.geoserver.geofence.spi.UserResolver;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.operation.MathTransform;
-import org.opengis.referencing.operation.TransformException;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
 
 import java.util.*;
 import java.util.Map.Entry;

--- a/src/services/pom.xml
+++ b/src/services/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <main-prefix>geofence</main-prefix>
 
-        <gt-version>29.2</gt-version>
+        <gt-version>30-SNAPSHOT</gt-version>
 
         <cxf-version>3.1.5</cxf-version>
         <activemq-version>5.3.0.4-fuse</activemq-version>


### PR DESCRIPTION
This changes covers GeoTools 30-SNAPSHOT API Change from ``org.opengis`` to ``org.geotools.api`` and resulting refactoring of the library.

This PR depends on https://github.com/geotools/geotools/pull/4367 and the availability of 30-SNAPSHOT.

See https://github.com/geoserver/geofence/issues/246